### PR TITLE
set .travis.yml golang to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.10
+  - 1.9
 
 script:
   - make build test-unit


### PR DESCRIPTION
1.10 didn't seem to work. This matches the original repo .travis.yml