### PR TITLE
Set service CA's management state to Managed

### DIFF
--- a/manifests/0000_09_service-ca-operator_06_config.yaml
+++ b/manifests/0000_09_service-ca-operator_06_config.yaml
@@ -4,7 +4,7 @@ kind: ServiceCA
 metadata:
   name: cluster
 spec:
-  managementState: Paused
+  managementState: Managed
   version: 4.0.0
   logLevel: "4"
   replicas: 1


### PR DESCRIPTION
SSCS now goes to no-op mode if service CA operator is running. Take
over its duties.