### PR TITLE
Make the signing CA last 1 year

### DIFF
--- a/pkg/operator/sync_signer_v4_00.go
+++ b/pkg/operator/sync_signer_v4_00.go
@@ -99,7 +99,7 @@ func manageSigningSecret_v4_00_to_latest(client coreclientv1.SecretsGetter, even
 		return existing, false, err
 	}
 
-	ca, err := crypto.MakeSelfSignedCAConfig(serviceServingCertSignerName(), 10)
+	ca, err := crypto.MakeSelfSignedCAConfig(serviceServingCertSignerName(), 365)
 	if err != nil {
 		return existing, false, err
 	}


### PR DESCRIPTION
Prolong the life of the service signing CA from 10 days to 730.