### PR TITLE
OpenAPIV3 validation for operator CRD

### DIFF
--- a/manifests/0000_09_service-ca-operator_02_crd.yaml
+++ b/manifests/0000_09_service-ca-operator_02_crd.yaml
@@ -3,12 +3,99 @@ kind: CustomResourceDefinition
 metadata:
   name: servicecas.operator.openshift.io
 spec:
-  scope: Cluster
   group: operator.openshift.io
-  version: v1
   names:
     kind: ServiceCA
     plural: servicecas
     singular: serviceca
-  subresources:
-    status: {}
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            logLevel:
+              description: logLevel is an intent based logging for an overall component.  It
+                does not give fine grained control, but it is a simple way to manage
+                coarse grained logging choices that operators have to interpret for
+                their operands.
+              type: string
+            managementState:
+              description: managementState indicates whether and how the operator
+                should manage the component
+              type: string
+            observedConfig:
+              description: observedConfig holds a sparse config that controller has
+                observed from the cluster state.  It exists in spec because it is
+                an input to the level for the operator
+              type: object
+            operandSpecs:
+              description: operandSpecs provide customization for functional units
+                within the component
+              items:
+                properties:
+                  name:
+                    description: name is the name of this unit.  The operator must
+                      be aware of it.
+                    type: string
+                  operandContainerSpecs:
+                    description: operandContainerSpecs are per-container options
+                    items:
+                      properties:
+                        name:
+                          description: name is the name of the container to modify
+                          type: string
+                        resources:
+                          description: resources are the requests and limits to place
+                            in the container.  Nil means to accept the defaults.
+                          type: object
+                      type: object
+                    type: array
+                  unsupportedResourcePatches:
+                    description: 'unsupportedResourcePatches are applied to the workload
+                      resource for this unit. This is an unsupported workaround if
+                      anything needs to be modified on the workload that is not otherwise
+                      configurable. TODO Decide: alternatively, we could simply include
+                      a RawExtension which is used in place of the "normal" default
+                      manifest'
+                    items:
+                      properties:
+                        patch:
+                          description: patch the patch itself
+                          type: string
+                        type:
+                          description: 'type is the type of patch to apply: jsonmerge,
+                            strategicmerge'
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              type: array
+            unsupportedConfigOverrides:
+              description: 'unsupportedConfigOverrides holds a sparse config that
+                will override any previously set options.  It only needs to be the
+                fields to override it will end up overlaying in the following order:
+                1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides'
+              type: object
+          type: object
+        status:
+          type: object
+  version: v1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
@mrogers950  I used [this generator](https://github.com/openshift/kubernetes-sigs-controller-tools/cmd/crd) to generate the CRD.

A few tweaks after generation:
- add `singular: serviceca` bc this comment doesn't exist in openshift/api/operator/v1/types_serviceca.go: `// +serviceca:singular=serviceca`
- removed generated status fields, don't need to validate those 
-  removed `required` for most fields

this PR is similar to [this](https://github.com/openshift/cluster-authentication-operator/pull/80)