### PR TITLE
Honor beta SSCS annotations

### DIFF
--- a/pkg/controller/api/api.go
+++ b/pkg/controller/api/api.go
@@ -7,14 +7,14 @@ import (
 )
 
 const (
-	InjectCABundleAnnotationName = "service.alpha.openshift.io/inject-cabundle"
-	BetaInjectCABundleAnnotationName = "service.beta.openshift.io/inject-cabundle"
-	InjectionDataKey             = "service-ca.crt"
+	InjectCABundleAnnotationName      = "service.beta.openshift.io/inject-cabundle"
+	AlphaInjectCABundleAnnotationName = "service.alpha.openshift.io/inject-cabundle"
+	InjectionDataKey                  = "service-ca.crt"
 )
 
 func HasInjectCABundleAnnotation(metadata v1.Object) bool {
-	return strings.EqualFold(metadata.GetAnnotations()[InjectCABundleAnnotationName], "true") ||
-		strings.EqualFold(metadata.GetAnnotations()[BetaInjectCABundleAnnotationName], "true")
+	return strings.EqualFold(metadata.GetAnnotations()[AlphaInjectCABundleAnnotationName], "true") ||
+		strings.EqualFold(metadata.GetAnnotations()[InjectCABundleAnnotationName], "true")
 }
 
 func HasInjectCABundleAnnotationUpdate(old, cur v1.Object) bool {
@@ -24,33 +24,33 @@ func HasInjectCABundleAnnotationUpdate(old, cur v1.Object) bool {
 // Annotations on service
 const (
 	// ServingCertSecretAnnotation stores the name of the secret to generate into.
-	ServingCertSecretAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"
-	BetaServingCertSecretAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
+	ServingCertSecretAnnotation      = "service.beta.openshift.io/serving-cert-secret-name"
+	AlphaServingCertSecretAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"
 	// ServingCertCreatedByAnnotation stores the of the signer common name.  This could be used later to see if the
 	// services need to have the the serving certs regenerated.  The presence and matching of this annotation prevents
 	// regeneration
-	ServingCertCreatedByAnnotation = "service.alpha.openshift.io/serving-cert-signed-by"
-	BetaServingCertCreatedByAnnotation = "service.beta.openshift.io/serving-cert-signed-by"
+	ServingCertCreatedByAnnotation      = "service.beta.openshift.io/serving-cert-signed-by"
+	AlphaServingCertCreatedByAnnotation = "service.alpha.openshift.io/serving-cert-signed-by"
 	// ServingCertErrorAnnotation stores the error that caused cert generation failures.
-	ServingCertErrorAnnotation = "service.alpha.openshift.io/serving-cert-generation-error"
-	BetaServingCertErrorAnnotation = "service.beta.openshift.io/serving-cert-generation-error"
+	ServingCertErrorAnnotation      = "service.beta.openshift.io/serving-cert-generation-error"
+	AlphaServingCertErrorAnnotation = "service.alpha.openshift.io/serving-cert-generation-error"
 	// ServingCertErrorNumAnnotation stores how many consecutive errors we've hit.  A value of the maxRetries will prevent
 	// the controller from reattempting until it is cleared.
-	ServingCertErrorNumAnnotation = "service.alpha.openshift.io/serving-cert-generation-error-num"
-	BetaServingCertErrorNumAnnotation = "service.beta.openshift.io/serving-cert-generation-error-num"
+	ServingCertErrorNumAnnotation      = "service.beta.openshift.io/serving-cert-generation-error-num"
+	AlphaServingCertErrorNumAnnotation = "service.alpha.openshift.io/serving-cert-generation-error-num"
 )
 
 // Annotations on secret
 const (
 	// ServiceUIDAnnotation is an annotation on a secret that indicates which service created it, by UID
-	ServiceUIDAnnotation = "service.alpha.openshift.io/originating-service-uid"
-	BetaServiceUIDAnnotation = "service.beta.openshift.io/originating-service-uid"
+	ServiceUIDAnnotation      = "service.beta.openshift.io/originating-service-uid"
+	AlphaServiceUIDAnnotation = "service.alpha.openshift.io/originating-service-uid"
 	// ServiceNameAnnotation is an annotation on a secret that indicates which service created it, by Name to allow reverse lookups on services
 	// for comparison against UIDs
-	ServiceNameAnnotation = "service.alpha.openshift.io/originating-service-name"
-	BetaServiceNameAnnotation = "service.beta.openshift.io/originating-service-name"
+	ServiceNameAnnotation      = "service.beta.openshift.io/originating-service-name"
+	AlphaServiceNameAnnotation = "service.alpha.openshift.io/originating-service-name"
 	// ServingCertExpiryAnnotation is an annotation that holds the expiry time of the certificate.  It accepts time in the
 	// RFC3339 format: 2018-11-29T17:44:39Z
-	ServingCertExpiryAnnotation = "service.alpha.openshift.io/expiry"
-	BetaServingCertExpiryAnnotation = "service.beta.openshift.io/expiry"
+	ServingCertExpiryAnnotation      = "service.beta.openshift.io/expiry"
+	AlphaServingCertExpiryAnnotation = "service.alpha.openshift.io/expiry"
 )

--- a/pkg/controller/api/api.go
+++ b/pkg/controller/api/api.go
@@ -8,11 +8,13 @@ import (
 
 const (
 	InjectCABundleAnnotationName = "service.alpha.openshift.io/inject-cabundle"
+	BetaInjectCABundleAnnotationName = "service.beta.openshift.io/inject-cabundle"
 	InjectionDataKey             = "service-ca.crt"
 )
 
 func HasInjectCABundleAnnotation(metadata v1.Object) bool {
-	return strings.EqualFold(metadata.GetAnnotations()[InjectCABundleAnnotationName], "true")
+	return strings.EqualFold(metadata.GetAnnotations()[InjectCABundleAnnotationName], "true") ||
+		strings.EqualFold(metadata.GetAnnotations()[BetaInjectCABundleAnnotationName], "true")
 }
 
 func HasInjectCABundleAnnotationUpdate(old, cur v1.Object) bool {
@@ -23,25 +25,32 @@ func HasInjectCABundleAnnotationUpdate(old, cur v1.Object) bool {
 const (
 	// ServingCertSecretAnnotation stores the name of the secret to generate into.
 	ServingCertSecretAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"
+	BetaServingCertSecretAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
 	// ServingCertCreatedByAnnotation stores the of the signer common name.  This could be used later to see if the
 	// services need to have the the serving certs regenerated.  The presence and matching of this annotation prevents
 	// regeneration
 	ServingCertCreatedByAnnotation = "service.alpha.openshift.io/serving-cert-signed-by"
+	BetaServingCertCreatedByAnnotation = "service.beta.openshift.io/serving-cert-signed-by"
 	// ServingCertErrorAnnotation stores the error that caused cert generation failures.
 	ServingCertErrorAnnotation = "service.alpha.openshift.io/serving-cert-generation-error"
+	BetaServingCertErrorAnnotation = "service.beta.openshift.io/serving-cert-generation-error"
 	// ServingCertErrorNumAnnotation stores how many consecutive errors we've hit.  A value of the maxRetries will prevent
 	// the controller from reattempting until it is cleared.
 	ServingCertErrorNumAnnotation = "service.alpha.openshift.io/serving-cert-generation-error-num"
+	BetaServingCertErrorNumAnnotation = "service.beta.openshift.io/serving-cert-generation-error-num"
 )
 
 // Annotations on secret
 const (
 	// ServiceUIDAnnotation is an annotation on a secret that indicates which service created it, by UID
 	ServiceUIDAnnotation = "service.alpha.openshift.io/originating-service-uid"
+	BetaServiceUIDAnnotation = "service.beta.openshift.io/originating-service-uid"
 	// ServiceNameAnnotation is an annotation on a secret that indicates which service created it, by Name to allow reverse lookups on services
 	// for comparison against UIDs
 	ServiceNameAnnotation = "service.alpha.openshift.io/originating-service-name"
+	BetaServiceNameAnnotation = "service.beta.openshift.io/originating-service-name"
 	// ServingCertExpiryAnnotation is an annotation that holds the expiry time of the certificate.  It accepts time in the
 	// RFC3339 format: 2018-11-29T17:44:39Z
 	ServingCertExpiryAnnotation = "service.alpha.openshift.io/expiry"
+	BetaServingCertExpiryAnnotation = "service.beta.openshift.io/expiry"
 )

--- a/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
+++ b/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
@@ -51,7 +51,7 @@ func TestSyncAPIService(t *testing.T) {
 			name: "requested and empty",
 			startingAPIServices: []runtime.Object{
 				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.AlphaInjectCABundleAnnotationName: "true"}},
 				},
 			},
 			key:                "foo",
@@ -62,7 +62,7 @@ func TestSyncAPIService(t *testing.T) {
 			name: "requested and nochange",
 			startingAPIServices: []runtime.Object{
 				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.AlphaInjectCABundleAnnotationName: "true"}},
 					Spec: apiregistrationapiv1.APIServiceSpec{
 						CABundle: []byte("content"),
 					},
@@ -76,7 +76,7 @@ func TestSyncAPIService(t *testing.T) {
 			name: "requested and different",
 			startingAPIServices: []runtime.Object{
 				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.AlphaInjectCABundleAnnotationName: "true"}},
 					Spec: apiregistrationapiv1.APIServiceSpec{
 						CABundle: []byte("old"),
 					},
@@ -90,7 +90,7 @@ func TestSyncAPIService(t *testing.T) {
 			name: "requested and empty beta",
 			startingAPIServices: []runtime.Object{
 				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
 				},
 			},
 			key:                "foo",
@@ -101,7 +101,7 @@ func TestSyncAPIService(t *testing.T) {
 			name: "requested and nochange beta",
 			startingAPIServices: []runtime.Object{
 				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
 					Spec: apiregistrationapiv1.APIServiceSpec{
 						CABundle: []byte("content"),
 					},
@@ -115,7 +115,7 @@ func TestSyncAPIService(t *testing.T) {
 			name: "requested and different beta",
 			startingAPIServices: []runtime.Object{
 				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
 					Spec: apiregistrationapiv1.APIServiceSpec{
 						CABundle: []byte("old"),
 					},

--- a/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
+++ b/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
@@ -17,23 +17,35 @@ import (
 	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
 
+func validateActions(t *testing.T, expectedActionsNum int, actions []clienttesting.Action) {
+	if len(actions) != expectedActionsNum {
+		t.Fatal(spew.Sdump(actions))
+	}
+	if expectedActionsNum == 0 {
+		return
+	}
+	if !actions[0].Matches("update", "apiservices") {
+		t.Error(spew.Sdump(actions))
+	}
+	actual := actions[0].(clienttesting.UpdateAction).GetObject().(*apiregistrationapiv1.APIService)
+	if expected := "content"; string(actual.Spec.CABundle) != expected {
+		t.Error(diff.ObjectDiff(expected, actual))
+	}
+}
+
 func TestSyncAPIService(t *testing.T) {
 	tests := []struct {
 		name                string
 		startingAPIServices []runtime.Object
 		key                 string
 		caBundle            []byte
-		validateActions     func(t *testing.T, actions []clienttesting.Action)
+		expectedActionsNum  int
 	}{
 		{
-			name:     "missing",
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
-			},
+			name:               "missing",
+			key:                "foo",
+			caBundle:           []byte("content"),
+			expectedActionsNum: 0,
 		},
 		{
 			name: "requested and empty",
@@ -42,20 +54,9 @@ func TestSyncAPIService(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
 				},
 			},
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "apiservices") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*apiregistrationapiv1.APIService)
-				if expected := "content"; string(actual.Spec.CABundle) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
-			},
+			key:                "foo",
+			caBundle:           []byte("content"),
+			expectedActionsNum: 1,
 		},
 		{
 			name: "requested and nochange",
@@ -67,16 +68,12 @@ func TestSyncAPIService(t *testing.T) {
 					},
 				},
 			},
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
-			},
+			key:                "foo",
+			caBundle:           []byte("content"),
+			expectedActionsNum: 0,
 		},
 		{
-			name: "requested and differe",
+			name: "requested and different",
 			startingAPIServices: []runtime.Object{
 				&apiregistrationapiv1.APIService{
 					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"}},
@@ -85,20 +82,48 @@ func TestSyncAPIService(t *testing.T) {
 					},
 				},
 			},
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "apiservices") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*apiregistrationapiv1.APIService)
-				if expected := "content"; string(actual.Spec.CABundle) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
+			key:                "foo",
+			caBundle:           []byte("content"),
+			expectedActionsNum: 1,
+		},
+		{
+			name: "requested and empty beta",
+			startingAPIServices: []runtime.Object{
+				&apiregistrationapiv1.APIService{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+				},
 			},
+			key:                "foo",
+			caBundle:           []byte("content"),
+			expectedActionsNum: 1,
+		},
+		{
+			name: "requested and nochange beta",
+			startingAPIServices: []runtime.Object{
+				&apiregistrationapiv1.APIService{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+					Spec: apiregistrationapiv1.APIServiceSpec{
+						CABundle: []byte("content"),
+					},
+				},
+			},
+			key:                "foo",
+			caBundle:           []byte("content"),
+			expectedActionsNum: 0,
+		},
+		{
+			name: "requested and different beta",
+			startingAPIServices: []runtime.Object{
+				&apiregistrationapiv1.APIService{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+					Spec: apiregistrationapiv1.APIServiceSpec{
+						CABundle: []byte("old"),
+					},
+				},
+			},
+			key:                "foo",
+			caBundle:           []byte("content"),
+			expectedActionsNum: 1,
 		},
 	}
 	for _, tc := range tests {
@@ -122,117 +147,7 @@ func TestSyncAPIService(t *testing.T) {
 				}
 			}
 
-			tc.validateActions(t, fakeClient.Actions())
-		})
-	}
-}
-
-func TestSyncAPIServiceBetaAnnotation(t *testing.T) {
-	tests := []struct {
-		name                string
-		startingAPIServices []runtime.Object
-		key                 string
-		caBundle            []byte
-		validateActions     func(t *testing.T, actions []clienttesting.Action)
-	}{
-		{
-			name:     "missing",
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
-			},
-		},
-		{
-			name: "requested and empty",
-			startingAPIServices: []runtime.Object{
-				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
-				},
-			},
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "apiservices") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*apiregistrationapiv1.APIService)
-				if expected := "content"; string(actual.Spec.CABundle) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
-			},
-		},
-		{
-			name: "requested and nochange",
-			startingAPIServices: []runtime.Object{
-				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
-					Spec: apiregistrationapiv1.APIServiceSpec{
-						CABundle: []byte("content"),
-					},
-				},
-			},
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
-			},
-		},
-		{
-			name: "requested and differe",
-			startingAPIServices: []runtime.Object{
-				&apiregistrationapiv1.APIService{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
-					Spec: apiregistrationapiv1.APIServiceSpec{
-						CABundle: []byte("old"),
-					},
-				},
-			},
-			key:      "foo",
-			caBundle: []byte("content"),
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "apiservices") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*apiregistrationapiv1.APIService)
-				if expected := "content"; string(actual.Spec.CABundle) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			fakeClient := apiserviceclientfake.NewSimpleClientset(tc.startingAPIServices...)
-			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-			for _, apiService := range tc.startingAPIServices {
-				index.Add(apiService)
-			}
-
-			c := &serviceServingCertUpdateController{
-				apiServiceLister: apiservicelister.NewAPIServiceLister(index),
-				apiServiceClient: fakeClient.ApiregistrationV1(),
-				caBundle:         tc.caBundle,
-			}
-
-			obj, err := c.Key("", tc.key)
-			if err == nil {
-				if err := c.Sync(obj); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			tc.validateActions(t, fakeClient.Actions())
+			validateActions(t, tc.expectedActionsNum, fakeClient.Actions())
 		})
 	}
 }

--- a/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
+++ b/pkg/controller/apiservicecabundle/controller/apiservice_cabundle_controller_test.go
@@ -126,3 +126,113 @@ func TestSyncAPIService(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncAPIServiceBetaAnnotation(t *testing.T) {
+	tests := []struct {
+		name                string
+		startingAPIServices []runtime.Object
+		key                 string
+		caBundle            []byte
+		validateActions     func(t *testing.T, actions []clienttesting.Action)
+	}{
+		{
+			name:     "missing",
+			key:      "foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "requested and empty",
+			startingAPIServices: []runtime.Object{
+				&apiregistrationapiv1.APIService{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+				},
+			},
+			key:      "foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "apiservices") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*apiregistrationapiv1.APIService)
+				if expected := "content"; string(actual.Spec.CABundle) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "requested and nochange",
+			startingAPIServices: []runtime.Object{
+				&apiregistrationapiv1.APIService{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+					Spec: apiregistrationapiv1.APIServiceSpec{
+						CABundle: []byte("content"),
+					},
+				},
+			},
+			key:      "foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "requested and differe",
+			startingAPIServices: []runtime.Object{
+				&apiregistrationapiv1.APIService{
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"}},
+					Spec: apiregistrationapiv1.APIServiceSpec{
+						CABundle: []byte("old"),
+					},
+				},
+			},
+			key:      "foo",
+			caBundle: []byte("content"),
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "apiservices") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*apiregistrationapiv1.APIService)
+				if expected := "content"; string(actual.Spec.CABundle) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := apiserviceclientfake.NewSimpleClientset(tc.startingAPIServices...)
+			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, apiService := range tc.startingAPIServices {
+				index.Add(apiService)
+			}
+
+			c := &serviceServingCertUpdateController{
+				apiServiceLister: apiservicelister.NewAPIServiceLister(index),
+				apiServiceClient: fakeClient.ApiregistrationV1(),
+				caBundle:         tc.caBundle,
+			}
+
+			obj, err := c.Key("", tc.key)
+			if err == nil {
+				if err := c.Sync(obj); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			tc.validateActions(t, fakeClient.Actions())
+		})
+	}
+}

--- a/pkg/controller/configmapcainjector/controller/configmap_injecting_controller_test.go
+++ b/pkg/controller/configmapcainjector/controller/configmap_injecting_controller_test.go
@@ -55,7 +55,7 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 				&v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "foo",
-						Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"},
+						Annotations: map[string]string{api.AlphaInjectCABundleAnnotationName: "true"},
 						Namespace:   "foo",
 					},
 					Data: map[string]string{},
@@ -72,7 +72,7 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 				&v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "foo",
-						Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"},
+						Annotations: map[string]string{api.AlphaInjectCABundleAnnotationName: "true"},
 						Namespace:   "foo",
 					},
 					Data: map[string]string{
@@ -91,7 +91,7 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 				&v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "foo",
-						Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"},
+						Annotations: map[string]string{api.AlphaInjectCABundleAnnotationName: "true"},
 						Namespace:   "foo",
 					},
 					Data: map[string]string{
@@ -110,7 +110,7 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 				&v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "foo",
-						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"},
 						Namespace:   "foo",
 					},
 					Data: map[string]string{},
@@ -127,7 +127,7 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 				&v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "foo",
-						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"},
 						Namespace:   "foo",
 					},
 					Data: map[string]string{
@@ -146,7 +146,7 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 				&v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:        "foo",
-						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Annotations: map[string]string{api.InjectCABundleAnnotationName: "true"},
 						Namespace:   "foo",
 					},
 					Data: map[string]string{

--- a/pkg/controller/configmapcainjector/controller/configmap_injecting_controller_test.go
+++ b/pkg/controller/configmapcainjector/controller/configmap_injecting_controller_test.go
@@ -143,3 +143,130 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncConfigMapCABundleBetaAnnotation(t *testing.T) {
+	tests := []struct {
+		name               string
+		startingConfigMaps []runtime.Object
+		namespace          string
+		cmName             string
+		caBundle           string
+		validateActions    func(t *testing.T, actions []clienttesting.Action)
+	}{
+		{
+			name:      "missing",
+			namespace: "foo",
+			cmName:    "foo",
+			caBundle:  "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+		{
+			name: "requested and empty",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Namespace:   "foo",
+					},
+					Data: map[string]string{},
+				},
+			},
+			namespace: "foo",
+			cmName:    "foo",
+			caBundle:  "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "configmaps") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
+				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "requested and different",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Namespace:   "foo",
+					},
+					Data: map[string]string{
+						api.InjectionDataKey: "foo",
+					},
+				},
+			},
+			namespace: "foo",
+			cmName:    "foo",
+			caBundle:  "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 1 {
+					t.Fatal(spew.Sdump(actions))
+				}
+				if !actions[0].Matches("update", "configmaps") {
+					t.Error(spew.Sdump(actions))
+				}
+				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
+				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
+					t.Error(diff.ObjectDiff(expected, actual))
+				}
+			},
+		},
+		{
+			name: "requested and same",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Namespace:   "foo",
+					},
+					Data: map[string]string{
+						api.InjectionDataKey: "content",
+					},
+				},
+			},
+			namespace: "foo",
+			cmName:    "foo",
+			caBundle:  "content",
+			validateActions: func(t *testing.T, actions []clienttesting.Action) {
+				if len(actions) != 0 {
+					t.Fatal(spew.Sdump(actions))
+				}
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset(tc.startingConfigMaps...)
+			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			for _, configMap := range tc.startingConfigMaps {
+				index.Add(configMap)
+			}
+			c := &configMapCABundleInjectionController{
+				configMapLister: listers.NewConfigMapLister(index),
+				configMapClient: fakeClient.CoreV1(),
+				ca:              tc.caBundle,
+			}
+
+			obj, err := c.Key(tc.namespace, tc.cmName)
+			if err == nil {
+				if err := c.Sync(obj); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			tc.validateActions(t, fakeClient.Actions())
+		})
+	}
+}

--- a/pkg/controller/configmapcainjector/controller/configmap_injecting_controller_test.go
+++ b/pkg/controller/configmapcainjector/controller/configmap_injecting_controller_test.go
@@ -17,6 +17,22 @@ import (
 	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
 
+func validateActions(t *testing.T, expectedActionsNum int, actions []clienttesting.Action) {
+	if len(actions) != expectedActionsNum {
+		t.Fatal(spew.Sdump(actions))
+	}
+	if expectedActionsNum == 0 {
+		return
+	}
+	if !actions[0].Matches("update", "configmaps") {
+		t.Error(spew.Sdump(actions))
+	}
+	actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
+	if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
+		t.Error(diff.ObjectDiff(expected, actual))
+	}
+}
+
 func TestSyncConfigMapCABundle(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -24,18 +40,14 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 		namespace          string
 		cmName             string
 		caBundle           string
-		validateActions    func(t *testing.T, actions []clienttesting.Action)
+		expectedActionsNum int
 	}{
 		{
-			name:      "missing",
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
-			},
+			name:               "missing",
+			namespace:          "foo",
+			cmName:             "foo",
+			caBundle:           "content",
+			expectedActionsNum: 0,
 		},
 		{
 			name: "requested and empty",
@@ -49,21 +61,10 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 					Data: map[string]string{},
 				},
 			},
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "configmaps") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
-				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
-			},
+			namespace:          "foo",
+			cmName:             "foo",
+			caBundle:           "content",
+			expectedActionsNum: 1,
 		},
 		{
 			name: "requested and different",
@@ -79,21 +80,10 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 					},
 				},
 			},
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "configmaps") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
-				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
-			},
+			namespace:          "foo",
+			cmName:             "foo",
+			caBundle:           "content",
+			expectedActionsNum: 1,
 		},
 		{
 			name: "requested and same",
@@ -109,14 +99,65 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 					},
 				},
 			},
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
+			namespace:          "foo",
+			cmName:             "foo",
+			caBundle:           "content",
+			expectedActionsNum: 0,
+		},
+		{
+			name: "requested and empty beta",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Namespace:   "foo",
+					},
+					Data: map[string]string{},
+				},
 			},
+			namespace:          "foo",
+			cmName:             "foo",
+			caBundle:           "content",
+			expectedActionsNum: 1,
+		},
+		{
+			name: "requested and different beta",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Namespace:   "foo",
+					},
+					Data: map[string]string{
+						api.InjectionDataKey: "foo",
+					},
+				},
+			},
+			namespace:          "foo",
+			cmName:             "foo",
+			caBundle:           "content",
+			expectedActionsNum: 1,
+		},
+		{
+			name: "requested and same beta",
+			startingConfigMaps: []runtime.Object{
+				&v1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "foo",
+						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
+						Namespace:   "foo",
+					},
+					Data: map[string]string{
+						api.InjectionDataKey: "content",
+					},
+				},
+			},
+			namespace:          "foo",
+			cmName:             "foo",
+			caBundle:           "content",
+			expectedActionsNum: 0,
 		},
 	}
 	for _, tc := range tests {
@@ -139,134 +180,7 @@ func TestSyncConfigMapCABundle(t *testing.T) {
 				}
 			}
 
-			tc.validateActions(t, fakeClient.Actions())
-		})
-	}
-}
-
-func TestSyncConfigMapCABundleBetaAnnotation(t *testing.T) {
-	tests := []struct {
-		name               string
-		startingConfigMaps []runtime.Object
-		namespace          string
-		cmName             string
-		caBundle           string
-		validateActions    func(t *testing.T, actions []clienttesting.Action)
-	}{
-		{
-			name:      "missing",
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
-			},
-		},
-		{
-			name: "requested and empty",
-			startingConfigMaps: []runtime.Object{
-				&v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "foo",
-						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
-						Namespace:   "foo",
-					},
-					Data: map[string]string{},
-				},
-			},
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "configmaps") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
-				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
-			},
-		},
-		{
-			name: "requested and different",
-			startingConfigMaps: []runtime.Object{
-				&v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "foo",
-						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
-						Namespace:   "foo",
-					},
-					Data: map[string]string{
-						api.InjectionDataKey: "foo",
-					},
-				},
-			},
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 1 {
-					t.Fatal(spew.Sdump(actions))
-				}
-				if !actions[0].Matches("update", "configmaps") {
-					t.Error(spew.Sdump(actions))
-				}
-				actual := actions[0].(clienttesting.UpdateAction).GetObject().(*v1.ConfigMap)
-				if expected := "content"; string(actual.Data[api.InjectionDataKey]) != expected {
-					t.Error(diff.ObjectDiff(expected, actual))
-				}
-			},
-		},
-		{
-			name: "requested and same",
-			startingConfigMaps: []runtime.Object{
-				&v1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:        "foo",
-						Annotations: map[string]string{api.BetaInjectCABundleAnnotationName: "true"},
-						Namespace:   "foo",
-					},
-					Data: map[string]string{
-						api.InjectionDataKey: "content",
-					},
-				},
-			},
-			namespace: "foo",
-			cmName:    "foo",
-			caBundle:  "content",
-			validateActions: func(t *testing.T, actions []clienttesting.Action) {
-				if len(actions) != 0 {
-					t.Fatal(spew.Sdump(actions))
-				}
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			fakeClient := fake.NewSimpleClientset(tc.startingConfigMaps...)
-			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-			for _, configMap := range tc.startingConfigMaps {
-				index.Add(configMap)
-			}
-			c := &configMapCABundleInjectionController{
-				configMapLister: listers.NewConfigMapLister(index),
-				configMapClient: fakeClient.CoreV1(),
-				ca:              tc.caBundle,
-			}
-
-			obj, err := c.Key(tc.namespace, tc.cmName)
-			if err == nil {
-				if err := c.Sync(obj); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			tc.validateActions(t, fakeClient.Actions())
+			validateActions(t, tc.expectedActionsNum, fakeClient.Actions())
 		})
 	}
 }

--- a/pkg/controller/servingcert/controller/secret_creating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller.go
@@ -136,8 +136,11 @@ func (sc *serviceServingCertController) generateCert(serviceCopy *v1.Service) er
 	if err != nil && !kapierrors.IsAlreadyExists(err) {
 		// if we have an error creating the secret, then try to update the service with that information.  If it fails,
 		// then we'll just try again later on re-list or because the service had already been updated and we'll get triggered again.
+		serviceCopy.Annotations[api.BetaServingCertErrorAnnotation] = err.Error()
 		serviceCopy.Annotations[api.ServingCertErrorAnnotation] = err.Error()
-		serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = strconv.Itoa(getNumFailures(serviceCopy) + 1)
+		numFailure := strconv.Itoa(getNumFailures(serviceCopy) + 1)
+		serviceCopy.Annotations[api.BetaServingCertErrorNumAnnotation] = numFailure
+		serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = numFailure
 		_, updateErr := sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
 
 		// if we're past the max retries and we successfully updated, then the sync loop successfully handled this service and we want to forget it
@@ -151,8 +154,11 @@ func (sc *serviceServingCertController) generateCert(serviceCopy *v1.Service) er
 		if err != nil {
 			// if we have an error creating the secret, then try to update the service with that information.  If it fails,
 			// then we'll just try again later on  re-list or because the service had already been updated and we'll get triggered again.
+			serviceCopy.Annotations[api.BetaServingCertErrorAnnotation] = err.Error()
 			serviceCopy.Annotations[api.ServingCertErrorAnnotation] = err.Error()
-			serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = strconv.Itoa(getNumFailures(serviceCopy) + 1)
+			numFailure := strconv.Itoa(getNumFailures(serviceCopy) + 1)
+			serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = numFailure
+			serviceCopy.Annotations[api.BetaServingCertErrorNumAnnotation] = numFailure
 			_, updateErr := sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
 
 			// if we're past the max retries and we successfully updated, then the sync loop successfully handled this service and we want to forget it
@@ -162,31 +168,41 @@ func (sc *serviceServingCertController) generateCert(serviceCopy *v1.Service) er
 			return err
 		}
 
-		if actualSecret.Annotations[api.ServiceUIDAnnotation] != string(serviceCopy.UID) {
+		if (actualSecret.Annotations[api.ServiceUIDAnnotation] != string(serviceCopy.UID)) && (actualSecret.Annotations[api.BetaServiceUIDAnnotation] != string(serviceCopy.UID)) {
 			serviceCopy.Annotations[api.ServingCertErrorAnnotation] = fmt.Sprintf("secret/%v references serviceUID %v, which does not match %v", actualSecret.Name, actualSecret.Annotations[api.ServiceUIDAnnotation], serviceCopy.UID)
-			serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = strconv.Itoa(getNumFailures(serviceCopy) + 1)
+			serviceCopy.Annotations[api.BetaServingCertErrorAnnotation] = fmt.Sprintf("secret/%v references serviceUID %v, which does not match %v", actualSecret.Name, actualSecret.Annotations[api.BetaServiceUIDAnnotation], serviceCopy.UID)
+			numFailure := strconv.Itoa(getNumFailures(serviceCopy) + 1)
+			serviceCopy.Annotations[api.BetaServingCertErrorNumAnnotation] = numFailure
+			serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = numFailure
 			_, updateErr := sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
 
 			// if we're past the max retries and we successfully updated, then the sync loop successfully handled this service and we want to forget it
 			if updateErr == nil && getNumFailures(serviceCopy) >= sc.maxRetries {
 				return nil
 			}
+			// TODO: Return BetaServingCertErrorAnnotation when removing alpha annotations.
 			return errors.New(serviceCopy.Annotations[api.ServingCertErrorAnnotation])
 		}
 	}
 
 	serviceCopy.Annotations[api.ServingCertCreatedByAnnotation] = sc.commonName()
+	serviceCopy.Annotations[api.BetaServingCertCreatedByAnnotation] = sc.commonName()
 	delete(serviceCopy.Annotations, api.ServingCertErrorAnnotation)
 	delete(serviceCopy.Annotations, api.ServingCertErrorNumAnnotation)
+	delete(serviceCopy.Annotations, api.BetaServingCertErrorAnnotation)
+	delete(serviceCopy.Annotations, api.BetaServingCertErrorNumAnnotation)
 	_, err = sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
 
 	return err
 }
 
 func getNumFailures(service *v1.Service) int {
-	numFailuresString := service.Annotations[api.ServingCertErrorNumAnnotation]
+	numFailuresString := service.Annotations[api.BetaServingCertErrorNumAnnotation]
 	if len(numFailuresString) == 0 {
-		return 0
+		numFailuresString = service.Annotations[api.ServingCertErrorNumAnnotation]
+		if len(numFailuresString) == 0 {
+			return 0
+		}
 	}
 
 	numFailures, err := strconv.Atoi(numFailuresString)
@@ -199,10 +215,14 @@ func getNumFailures(service *v1.Service) int {
 
 func (sc *serviceServingCertController) requiresCertGeneration(service *v1.Service) bool {
 	// check the secret since it could not have been created yet
-	secretName := service.Annotations[api.ServingCertSecretAnnotation]
+	secretName := service.Annotations[api.BetaServingCertSecretAnnotation]
 	if len(secretName) == 0 {
-		return false
+		secretName = service.Annotations[api.ServingCertSecretAnnotation]
+		if len(secretName) == 0 {
+			return false
+		}
 	}
+
 	_, err := sc.secretLister.Secrets(service.Namespace).Get(secretName)
 	if kapierrors.IsNotFound(err) {
 		// we have not created the secret yet
@@ -214,7 +234,7 @@ func (sc *serviceServingCertController) requiresCertGeneration(service *v1.Servi
 	}
 
 	// check to see if the service was updated by us
-	if service.Annotations[api.ServingCertCreatedByAnnotation] == sc.commonName() {
+	if service.Annotations[api.BetaServingCertCreatedByAnnotation] == sc.commonName() || service.Annotations[api.ServingCertCreatedByAnnotation] == sc.commonName() {
 		return false
 	}
 	// we have failed too many times on this service, give up
@@ -241,6 +261,21 @@ func ownerRef(service *v1.Service) metav1.OwnerReference {
 }
 
 func toBaseSecret(service *v1.Service) *v1.Secret {
+	// Use beta annotations
+	if _, ok := service.Annotations[api.BetaServingCertSecretAnnotation]; ok {
+		return &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      service.Annotations[api.BetaServingCertSecretAnnotation],
+				Namespace: service.Namespace,
+				Annotations: map[string]string{
+					api.BetaServiceUIDAnnotation:  string(service.UID),
+					api.BetaServiceNameAnnotation: service.Name,
+				},
+			},
+			Type: v1.SecretTypeTLS,
+		}
+	}
+	// Use alpha annotations
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      service.Annotations[api.ServingCertSecretAnnotation],
@@ -279,6 +314,7 @@ func toRequiredSecret(dnsSuffix string, ca *crypto.CA, service *v1.Service, secr
 	}
 
 	secretCopy.Annotations[api.ServingCertExpiryAnnotation] = servingCert.Certs[0].NotAfter.Format(time.RFC3339)
+	secretCopy.Annotations[api.BetaServingCertExpiryAnnotation] = servingCert.Certs[0].NotAfter.Format(time.RFC3339)
 	secretCopy.Data[v1.TLSCertKey] = certBytes
 	secretCopy.Data[v1.TLSPrivateKeyKey] = keyBytes
 

--- a/pkg/controller/servingcert/controller/secret_creating_controller_test.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller_test.go
@@ -136,13 +136,13 @@ func TestBasicControllerFlow(t *testing.T) {
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
 	expectedServiceAnnotations := map[string]string{
-		api.ServingCertSecretAnnotation:        expectedSecretName,
-		api.ServingCertCreatedByAnnotation:     caName,
-		api.BetaServingCertCreatedByAnnotation: caName,
+		api.AlphaServingCertSecretAnnotation:    expectedSecretName,
+		api.AlphaServingCertCreatedByAnnotation: caName,
+		api.ServingCertCreatedByAnnotation:      caName,
 	}
 	expectedSecretAnnotations := map[string]string{
-		api.ServiceUIDAnnotation:  serviceUID,
-		api.ServiceNameAnnotation: serviceName,
+		api.AlphaServiceUIDAnnotation:  serviceUID,
+		api.AlphaServiceNameAnnotation: serviceName,
 	}
 	namespace := "ns"
 
@@ -150,7 +150,7 @@ func TestBasicControllerFlow(t *testing.T) {
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.AlphaServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -175,8 +175,8 @@ func TestBasicControllerFlow(t *testing.T) {
 				t.Errorf("expected %v, got %v", namespace, newSecret.Namespace)
 				continue
 			}
+			delete(newSecret.Annotations, api.AlphaServingCertExpiryAnnotation)
 			delete(newSecret.Annotations, api.ServingCertExpiryAnnotation)
-			delete(newSecret.Annotations, api.BetaServingCertExpiryAnnotation)
 			if !reflect.DeepEqual(newSecret.Annotations, expectedSecretAnnotations) {
 				t.Errorf("expected %v, got %v", expectedSecretAnnotations, newSecret.Annotations)
 				continue
@@ -228,13 +228,13 @@ func TestBasicControllerFlowBetaAnnotation(t *testing.T) {
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
 	expectedServiceAnnotations := map[string]string{
-		api.BetaServingCertSecretAnnotation:    expectedSecretName,
-		api.ServingCertCreatedByAnnotation:     caName,
-		api.BetaServingCertCreatedByAnnotation: caName,
+		api.ServingCertSecretAnnotation:         expectedSecretName,
+		api.AlphaServingCertCreatedByAnnotation: caName,
+		api.ServingCertCreatedByAnnotation:      caName,
 	}
 	expectedSecretAnnotations := map[string]string{
-		api.BetaServiceUIDAnnotation:  serviceUID,
-		api.BetaServiceNameAnnotation: serviceName,
+		api.ServiceUIDAnnotation:  serviceUID,
+		api.ServiceNameAnnotation: serviceName,
 	}
 	namespace := "ns"
 
@@ -242,7 +242,7 @@ func TestBasicControllerFlowBetaAnnotation(t *testing.T) {
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.BetaServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -267,8 +267,8 @@ func TestBasicControllerFlowBetaAnnotation(t *testing.T) {
 				t.Errorf("expected %v, got %v", namespace, newSecret.Namespace)
 				continue
 			}
+			delete(newSecret.Annotations, api.AlphaServingCertExpiryAnnotation)
 			delete(newSecret.Annotations, api.ServingCertExpiryAnnotation)
-			delete(newSecret.Annotations, api.BetaServingCertExpiryAnnotation)
 			if !reflect.DeepEqual(newSecret.Annotations, expectedSecretAnnotations) {
 				t.Errorf("expected %v, got %v", expectedSecretAnnotations, newSecret.Annotations)
 				continue
@@ -305,7 +305,7 @@ func TestAlreadyExistingSecretControllerFlow(t *testing.T) {
 	expectedSecretName := "new-secret"
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
-	expectedSecretAnnotations := map[string]string{api.ServiceUIDAnnotation: serviceUID, api.ServiceNameAnnotation: serviceName}
+	expectedSecretAnnotations := map[string]string{api.AlphaServiceUIDAnnotation: serviceUID, api.AlphaServiceNameAnnotation: serviceName}
 	namespace := "ns"
 
 	existingSecret := &v1.Secret{}
@@ -332,16 +332,16 @@ func TestAlreadyExistingSecretControllerFlow(t *testing.T) {
 	go controller.Run(1, stopChannel)
 
 	expectedServiceAnnotations := map[string]string{
-		api.ServingCertSecretAnnotation:        expectedSecretName,
-		api.ServingCertCreatedByAnnotation:     caName,
-		api.BetaServingCertCreatedByAnnotation: caName,
+		api.AlphaServingCertSecretAnnotation:    expectedSecretName,
+		api.AlphaServingCertCreatedByAnnotation: caName,
+		api.ServingCertCreatedByAnnotation:      caName,
 	}
 
 	serviceToAdd := &v1.Service{}
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.AlphaServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -387,7 +387,7 @@ func TestAlreadyExistingSecretControllerFlowBetaAnnotation(t *testing.T) {
 	expectedSecretName := "new-secret"
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
-	expectedSecretAnnotations := map[string]string{api.ServiceUIDAnnotation: serviceUID, api.ServiceNameAnnotation: serviceName}
+	expectedSecretAnnotations := map[string]string{api.AlphaServiceUIDAnnotation: serviceUID, api.AlphaServiceNameAnnotation: serviceName}
 	namespace := "ns"
 
 	existingSecret := &v1.Secret{}
@@ -414,16 +414,16 @@ func TestAlreadyExistingSecretControllerFlowBetaAnnotation(t *testing.T) {
 	go controller.Run(1, stopChannel)
 
 	expectedServiceAnnotations := map[string]string{
-		api.BetaServingCertSecretAnnotation:    expectedSecretName,
-		api.ServingCertCreatedByAnnotation:     caName,
-		api.BetaServingCertCreatedByAnnotation: caName,
+		api.ServingCertSecretAnnotation:         expectedSecretName,
+		api.AlphaServingCertCreatedByAnnotation: caName,
+		api.ServingCertCreatedByAnnotation:      caName,
 	}
 
 	serviceToAdd := &v1.Service{}
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.BetaServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -477,9 +477,9 @@ func TestAlreadyExistingSecretForDifferentUIDControllerFlow(t *testing.T) {
 	existingSecret.Namespace = namespace
 	existingSecret.Type = v1.SecretTypeTLS
 	existingSecret.Annotations = map[string]string{
-		api.ServiceUIDAnnotation:     "wrong-uid",
-		api.BetaServiceUIDAnnotation: "wrong-uid",
-		api.ServiceNameAnnotation:    serviceName,
+		api.AlphaServiceUIDAnnotation:  "wrong-uid",
+		api.ServiceUIDAnnotation:       "wrong-uid",
+		api.AlphaServiceNameAnnotation: serviceName,
 	}
 
 	_, kubeclient, fakeWatch, _, controller, informerFactory := controllerSetup([]runtime.Object{existingSecret}, t)
@@ -500,18 +500,18 @@ func TestAlreadyExistingSecretForDifferentUIDControllerFlow(t *testing.T) {
 	go controller.Run(1, stopChannel)
 
 	expectedServiceAnnotations := map[string]string{
-		api.ServingCertSecretAnnotation:       expectedSecretName,
-		api.ServingCertErrorAnnotation:        expectedError,
-		api.BetaServingCertErrorAnnotation:    expectedError,
-		api.ServingCertErrorNumAnnotation:     "1",
-		api.BetaServingCertErrorNumAnnotation: "1",
+		api.AlphaServingCertSecretAnnotation:   expectedSecretName,
+		api.AlphaServingCertErrorAnnotation:    expectedError,
+		api.ServingCertErrorAnnotation:         expectedError,
+		api.AlphaServingCertErrorNumAnnotation: "1",
+		api.ServingCertErrorNumAnnotation:      "1",
 	}
 
 	serviceToAdd := &v1.Service{}
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.AlphaServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -564,9 +564,9 @@ func TestAlreadyExistingSecretForDifferentUIDControllerFlowBetaAnnotation(t *tes
 	existingSecret.Namespace = namespace
 	existingSecret.Type = v1.SecretTypeTLS
 	existingSecret.Annotations = map[string]string{
-		api.ServiceUIDAnnotation:     "wrong-uid",
-		api.BetaServiceUIDAnnotation: "wrong-uid",
-		api.ServiceNameAnnotation:    serviceName,
+		api.AlphaServiceUIDAnnotation:  "wrong-uid",
+		api.ServiceUIDAnnotation:       "wrong-uid",
+		api.AlphaServiceNameAnnotation: serviceName,
 	}
 
 	_, kubeclient, fakeWatch, _, controller, informerFactory := controllerSetup([]runtime.Object{existingSecret}, t)
@@ -587,18 +587,18 @@ func TestAlreadyExistingSecretForDifferentUIDControllerFlowBetaAnnotation(t *tes
 	go controller.Run(1, stopChannel)
 
 	expectedServiceAnnotations := map[string]string{
-		api.BetaServingCertSecretAnnotation:   expectedSecretName,
-		api.ServingCertErrorAnnotation:        expectedError,
-		api.BetaServingCertErrorAnnotation:    expectedError,
-		api.ServingCertErrorNumAnnotation:     "1",
-		api.BetaServingCertErrorNumAnnotation: "1",
+		api.ServingCertSecretAnnotation:        expectedSecretName,
+		api.AlphaServingCertErrorAnnotation:    expectedError,
+		api.ServingCertErrorAnnotation:         expectedError,
+		api.AlphaServingCertErrorNumAnnotation: "1",
+		api.ServingCertErrorNumAnnotation:      "1",
 	}
 
 	serviceToAdd := &v1.Service{}
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.BetaServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -664,18 +664,18 @@ func TestSecretCreationErrorControllerFlow(t *testing.T) {
 	go controller.Run(1, stopChannel)
 
 	expectedServiceAnnotations := map[string]string{
-		api.ServingCertSecretAnnotation:       expectedSecretName,
-		api.ServingCertErrorAnnotation:        expectedError,
-		api.BetaServingCertErrorAnnotation:    expectedError,
-		api.ServingCertErrorNumAnnotation:     "1",
-		api.BetaServingCertErrorNumAnnotation: "1",
+		api.AlphaServingCertSecretAnnotation:   expectedSecretName,
+		api.AlphaServingCertErrorAnnotation:    expectedError,
+		api.ServingCertErrorAnnotation:         expectedError,
+		api.AlphaServingCertErrorNumAnnotation: "1",
+		api.ServingCertErrorNumAnnotation:      "1",
 	}
 
 	serviceToAdd := &v1.Service{}
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.AlphaServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -734,18 +734,18 @@ func TestSecretCreationErrorControllerFlowBetaAnnotation(t *testing.T) {
 	go controller.Run(1, stopChannel)
 
 	expectedServiceAnnotations := map[string]string{
-		api.BetaServingCertSecretAnnotation:   expectedSecretName,
-		api.ServingCertErrorAnnotation:        expectedError,
-		api.BetaServingCertErrorAnnotation:    expectedError,
-		api.ServingCertErrorNumAnnotation:     "1",
-		api.BetaServingCertErrorNumAnnotation: "1",
+		api.ServingCertSecretAnnotation:        expectedSecretName,
+		api.AlphaServingCertErrorAnnotation:    expectedError,
+		api.ServingCertErrorAnnotation:         expectedError,
+		api.AlphaServingCertErrorNumAnnotation: "1",
+		api.ServingCertErrorNumAnnotation:      "1",
 	}
 
 	serviceToAdd := &v1.Service{}
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.BetaServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	t.Log("waiting to reach syncHandler")
@@ -776,6 +776,85 @@ func TestSecretCreationErrorControllerFlowBetaAnnotation(t *testing.T) {
 }
 
 func TestSkipGenerationControllerFlow(t *testing.T) {
+	stopChannel := make(chan struct{})
+	defer close(stopChannel)
+	received := make(chan bool)
+
+	expectedSecretName := "new-secret"
+	serviceName := "svc-name"
+	serviceUID := "some-uid"
+	namespace := "ns"
+
+	caName, kubeclient, fakeWatch, fakeSecretWatch, controller, informerFactory := controllerSetup([]runtime.Object{}, t)
+	kubeclient.PrependReactor("update", "service", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &v1.Service{}, kapierrors.NewForbidden(v1.Resource("fdsa"), "new-service", fmt.Errorf("any service reason"))
+	})
+	kubeclient.PrependReactor("create", "secret", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &v1.Secret{}, kapierrors.NewForbidden(v1.Resource("asdf"), "new-secret", fmt.Errorf("any reason"))
+	})
+	kubeclient.PrependReactor("update", "secret", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &v1.Secret{}, kapierrors.NewForbidden(v1.Resource("asdf"), "new-secret", fmt.Errorf("any reason"))
+	})
+	controller.syncHandler = func(obj metav1.Object) error {
+		defer func() { received <- true }()
+
+		err := controller.syncService(obj)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		return err
+	}
+
+	secretToAdd := &v1.Secret{}
+	secretToAdd.Name = expectedSecretName
+	secretToAdd.Namespace = namespace
+	fakeSecretWatch.Add(secretToAdd)
+
+	informerFactory.Start(stopChannel)
+	go controller.Run(1, stopChannel)
+
+	serviceToAdd := &v1.Service{}
+	serviceToAdd.Name = serviceName
+	serviceToAdd.Namespace = namespace
+	serviceToAdd.UID = types.UID(serviceUID)
+	serviceToAdd.Annotations = map[string]string{api.AlphaServingCertSecretAnnotation: expectedSecretName, api.AlphaServingCertErrorAnnotation: "any-error", api.AlphaServingCertErrorNumAnnotation: "11"}
+	fakeWatch.Add(serviceToAdd)
+
+	t.Log("waiting to reach syncHandler")
+	select {
+	case <-received:
+	case <-time.After(time.Duration(30 * time.Second)):
+		t.Fatalf("failed to call into syncService")
+	}
+
+	for _, action := range kubeclient.Actions() {
+		switch action.GetVerb() {
+		case "update", "create":
+			t.Errorf("no mutation expected, but we got %v", action)
+		}
+	}
+
+	kubeclient.ClearActions()
+	serviceToAdd.Annotations = map[string]string{api.AlphaServingCertSecretAnnotation: expectedSecretName, api.AlphaServingCertCreatedByAnnotation: caName}
+	fakeWatch.Add(serviceToAdd)
+
+	t.Log("waiting to reach syncHandler")
+	select {
+	case <-received:
+	case <-time.After(time.Duration(30 * time.Second)):
+		t.Fatalf("failed to call into syncService")
+	}
+
+	for _, action := range kubeclient.Actions() {
+		switch action.GetVerb() {
+		case "update", "create":
+			t.Errorf("no mutation expected, but we got %v", action)
+		}
+	}
+}
+
+func TestSkipGenerationControllerFlowBetaAnnotation(t *testing.T) {
 	stopChannel := make(chan struct{})
 	defer close(stopChannel)
 	received := make(chan bool)
@@ -854,85 +933,6 @@ func TestSkipGenerationControllerFlow(t *testing.T) {
 	}
 }
 
-func TestSkipGenerationControllerFlowBetaAnnotation(t *testing.T) {
-	stopChannel := make(chan struct{})
-	defer close(stopChannel)
-	received := make(chan bool)
-
-	expectedSecretName := "new-secret"
-	serviceName := "svc-name"
-	serviceUID := "some-uid"
-	namespace := "ns"
-
-	caName, kubeclient, fakeWatch, fakeSecretWatch, controller, informerFactory := controllerSetup([]runtime.Object{}, t)
-	kubeclient.PrependReactor("update", "service", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &v1.Service{}, kapierrors.NewForbidden(v1.Resource("fdsa"), "new-service", fmt.Errorf("any service reason"))
-	})
-	kubeclient.PrependReactor("create", "secret", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &v1.Secret{}, kapierrors.NewForbidden(v1.Resource("asdf"), "new-secret", fmt.Errorf("any reason"))
-	})
-	kubeclient.PrependReactor("update", "secret", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
-		return true, &v1.Secret{}, kapierrors.NewForbidden(v1.Resource("asdf"), "new-secret", fmt.Errorf("any reason"))
-	})
-	controller.syncHandler = func(obj metav1.Object) error {
-		defer func() { received <- true }()
-
-		err := controller.syncService(obj)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-
-		return err
-	}
-
-	secretToAdd := &v1.Secret{}
-	secretToAdd.Name = expectedSecretName
-	secretToAdd.Namespace = namespace
-	fakeSecretWatch.Add(secretToAdd)
-
-	informerFactory.Start(stopChannel)
-	go controller.Run(1, stopChannel)
-
-	serviceToAdd := &v1.Service{}
-	serviceToAdd.Name = serviceName
-	serviceToAdd.Namespace = namespace
-	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.BetaServingCertSecretAnnotation: expectedSecretName, api.BetaServingCertErrorAnnotation: "any-error", api.BetaServingCertErrorNumAnnotation: "11"}
-	fakeWatch.Add(serviceToAdd)
-
-	t.Log("waiting to reach syncHandler")
-	select {
-	case <-received:
-	case <-time.After(time.Duration(30 * time.Second)):
-		t.Fatalf("failed to call into syncService")
-	}
-
-	for _, action := range kubeclient.Actions() {
-		switch action.GetVerb() {
-		case "update", "create":
-			t.Errorf("no mutation expected, but we got %v", action)
-		}
-	}
-
-	kubeclient.ClearActions()
-	serviceToAdd.Annotations = map[string]string{api.BetaServingCertSecretAnnotation: expectedSecretName, api.BetaServingCertCreatedByAnnotation: caName}
-	fakeWatch.Add(serviceToAdd)
-
-	t.Log("waiting to reach syncHandler")
-	select {
-	case <-received:
-	case <-time.After(time.Duration(30 * time.Second)):
-		t.Fatalf("failed to call into syncService")
-	}
-
-	for _, action := range kubeclient.Actions() {
-		switch action.GetVerb() {
-		case "update", "create":
-			t.Errorf("no mutation expected, but we got %v", action)
-		}
-	}
-}
-
 func TestRecreateSecretControllerFlow(t *testing.T) {
 	stopChannel := make(chan struct{})
 	defer close(stopChannel)
@@ -956,11 +956,11 @@ func TestRecreateSecretControllerFlow(t *testing.T) {
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
 	expectedServiceAnnotations := map[string]string{
-		api.ServingCertSecretAnnotation:        expectedSecretName,
-		api.ServingCertCreatedByAnnotation:     caName,
-		api.BetaServingCertCreatedByAnnotation: caName,
+		api.AlphaServingCertSecretAnnotation:    expectedSecretName,
+		api.AlphaServingCertCreatedByAnnotation: caName,
+		api.ServingCertCreatedByAnnotation:      caName,
 	}
-	expectedSecretAnnotations := map[string]string{api.ServiceUIDAnnotation: serviceUID, api.ServiceNameAnnotation: serviceName}
+	expectedSecretAnnotations := map[string]string{api.AlphaServiceUIDAnnotation: serviceUID, api.AlphaServiceNameAnnotation: serviceName}
 	expectedOwnerRef := []metav1.OwnerReference{{APIVersion: "v1", Kind: "Service", Name: serviceName, UID: types.UID(serviceUID)}}
 	namespace := "ns"
 
@@ -968,13 +968,13 @@ func TestRecreateSecretControllerFlow(t *testing.T) {
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.AlphaServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	secretToDelete := &v1.Secret{}
 	secretToDelete.Name = expectedSecretName
 	secretToDelete.Namespace = namespace
-	secretToDelete.Annotations = map[string]string{api.ServiceNameAnnotation: serviceName}
+	secretToDelete.Annotations = map[string]string{api.AlphaServiceNameAnnotation: serviceName}
 
 	t.Log("waiting to reach syncHandler")
 	select {
@@ -998,8 +998,8 @@ func TestRecreateSecretControllerFlow(t *testing.T) {
 				t.Errorf("expected %v, got %v", namespace, newSecret.Namespace)
 				continue
 			}
+			delete(newSecret.Annotations, api.AlphaServingCertExpiryAnnotation)
 			delete(newSecret.Annotations, api.ServingCertExpiryAnnotation)
-			delete(newSecret.Annotations, api.BetaServingCertExpiryAnnotation)
 			if !reflect.DeepEqual(newSecret.Annotations, expectedSecretAnnotations) {
 				t.Errorf("expected %v, got %v", expectedSecretAnnotations, newSecret.Annotations)
 				continue
@@ -1055,8 +1055,8 @@ func TestRecreateSecretControllerFlow(t *testing.T) {
 				t.Errorf("expected %v, got %v", namespace, newSecret.Namespace)
 				continue
 			}
+			delete(newSecret.Annotations, api.AlphaServingCertExpiryAnnotation)
 			delete(newSecret.Annotations, api.ServingCertExpiryAnnotation)
-			delete(newSecret.Annotations, api.BetaServingCertExpiryAnnotation)
 			if !reflect.DeepEqual(newSecret.Annotations, expectedSecretAnnotations) {
 				t.Errorf("expected %v, got %v", expectedSecretAnnotations, newSecret.Annotations)
 				continue
@@ -1101,11 +1101,11 @@ func TestRecreateSecretControllerFlowBetaAnnotation(t *testing.T) {
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
 	expectedServiceAnnotations := map[string]string{
-		api.BetaServingCertSecretAnnotation:    expectedSecretName,
-		api.ServingCertCreatedByAnnotation:     caName,
-		api.BetaServingCertCreatedByAnnotation: caName,
+		api.ServingCertSecretAnnotation:         expectedSecretName,
+		api.AlphaServingCertCreatedByAnnotation: caName,
+		api.ServingCertCreatedByAnnotation:      caName,
 	}
-	expectedSecretAnnotations := map[string]string{api.BetaServiceUIDAnnotation: serviceUID, api.BetaServiceNameAnnotation: serviceName}
+	expectedSecretAnnotations := map[string]string{api.ServiceUIDAnnotation: serviceUID, api.ServiceNameAnnotation: serviceName}
 	expectedOwnerRef := []metav1.OwnerReference{{APIVersion: "v1", Kind: "Service", Name: serviceName, UID: types.UID(serviceUID)}}
 	namespace := "ns"
 
@@ -1113,13 +1113,13 @@ func TestRecreateSecretControllerFlowBetaAnnotation(t *testing.T) {
 	serviceToAdd.Name = serviceName
 	serviceToAdd.Namespace = namespace
 	serviceToAdd.UID = types.UID(serviceUID)
-	serviceToAdd.Annotations = map[string]string{api.BetaServingCertSecretAnnotation: expectedSecretName}
+	serviceToAdd.Annotations = map[string]string{api.ServingCertSecretAnnotation: expectedSecretName}
 	fakeWatch.Add(serviceToAdd)
 
 	secretToDelete := &v1.Secret{}
 	secretToDelete.Name = expectedSecretName
 	secretToDelete.Namespace = namespace
-	secretToDelete.Annotations = map[string]string{api.ServiceNameAnnotation: serviceName}
+	secretToDelete.Annotations = map[string]string{api.AlphaServiceNameAnnotation: serviceName}
 
 	t.Log("waiting to reach syncHandler")
 	select {
@@ -1143,8 +1143,8 @@ func TestRecreateSecretControllerFlowBetaAnnotation(t *testing.T) {
 				t.Errorf("expected %v, got %v", namespace, newSecret.Namespace)
 				continue
 			}
+			delete(newSecret.Annotations, api.AlphaServingCertExpiryAnnotation)
 			delete(newSecret.Annotations, api.ServingCertExpiryAnnotation)
-			delete(newSecret.Annotations, api.BetaServingCertExpiryAnnotation)
 			if !reflect.DeepEqual(newSecret.Annotations, expectedSecretAnnotations) {
 				t.Errorf("expected %v, got %v", expectedSecretAnnotations, newSecret.Annotations)
 				continue
@@ -1200,8 +1200,8 @@ func TestRecreateSecretControllerFlowBetaAnnotation(t *testing.T) {
 				t.Errorf("expected %v, got %v", namespace, newSecret.Namespace)
 				continue
 			}
+			delete(newSecret.Annotations, api.AlphaServingCertExpiryAnnotation)
 			delete(newSecret.Annotations, api.ServingCertExpiryAnnotation)
-			delete(newSecret.Annotations, api.BetaServingCertExpiryAnnotation)
 			if !reflect.DeepEqual(newSecret.Annotations, expectedSecretAnnotations) {
 				t.Errorf("expected %v, got %v", expectedSecretAnnotations, newSecret.Annotations)
 				continue

--- a/pkg/controller/servingcert/controller/secret_updating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller.go
@@ -101,10 +101,10 @@ func (sc *serviceServingCertUpdateController) requiresRegeneration(secret *v1.Se
 		return false, nil
 	}
 
-	if sharedService.Annotations[api.ServingCertSecretAnnotation] != secret.Name {
+	if sharedService.Annotations[api.BetaServingCertSecretAnnotation] != secret.Name && sharedService.Annotations[api.ServingCertSecretAnnotation] != secret.Name {
 		return false, nil
 	}
-	if secret.Annotations[api.ServiceUIDAnnotation] != string(sharedService.UID) {
+	if secret.Annotations[api.BetaServiceUIDAnnotation] != string(sharedService.UID) && secret.Annotations[api.ServiceUIDAnnotation] != string(sharedService.UID) {
 		return false, nil
 	}
 
@@ -116,9 +116,12 @@ func (sc *serviceServingCertUpdateController) requiresRegeneration(secret *v1.Se
 
 	// if we don't have the annotation for expiry, just go ahead and regenerate.  It's easier than writing a
 	// secondary logic flow that creates the expiry dates
-	expiryString, ok := secret.Annotations[api.ServingCertExpiryAnnotation]
+	expiryString, ok := secret.Annotations[api.BetaServingCertExpiryAnnotation]
 	if !ok {
-		return true, sharedService
+		expiryString, ok = secret.Annotations[api.ServingCertExpiryAnnotation]
+		if !ok {
+			return true, sharedService
+		}
 	}
 	expiry, err := time.Parse(time.RFC3339, expiryString)
 	if err != nil {
@@ -133,6 +136,9 @@ func (sc *serviceServingCertUpdateController) requiresRegeneration(secret *v1.Se
 }
 
 func toServiceName(secret *v1.Secret) (string, bool) {
-	serviceName := secret.Annotations[api.ServiceNameAnnotation]
+	serviceName := secret.Annotations[api.BetaServiceNameAnnotation]
+	if len(serviceName) == 0 {
+		serviceName = secret.Annotations[api.ServiceNameAnnotation]
+	}
 	return serviceName, len(serviceName) != 0
 }

--- a/pkg/controller/servingcert/controller/secret_updating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller.go
@@ -101,10 +101,10 @@ func (sc *serviceServingCertUpdateController) requiresRegeneration(secret *v1.Se
 		return false, nil
 	}
 
-	if sharedService.Annotations[api.BetaServingCertSecretAnnotation] != secret.Name && sharedService.Annotations[api.ServingCertSecretAnnotation] != secret.Name {
+	if sharedService.Annotations[api.ServingCertSecretAnnotation] != secret.Name && sharedService.Annotations[api.AlphaServingCertSecretAnnotation] != secret.Name {
 		return false, nil
 	}
-	if secret.Annotations[api.BetaServiceUIDAnnotation] != string(sharedService.UID) && secret.Annotations[api.ServiceUIDAnnotation] != string(sharedService.UID) {
+	if secret.Annotations[api.ServiceUIDAnnotation] != string(sharedService.UID) && secret.Annotations[api.AlphaServiceUIDAnnotation] != string(sharedService.UID) {
 		return false, nil
 	}
 
@@ -116,9 +116,9 @@ func (sc *serviceServingCertUpdateController) requiresRegeneration(secret *v1.Se
 
 	// if we don't have the annotation for expiry, just go ahead and regenerate.  It's easier than writing a
 	// secondary logic flow that creates the expiry dates
-	expiryString, ok := secret.Annotations[api.BetaServingCertExpiryAnnotation]
+	expiryString, ok := secret.Annotations[api.ServingCertExpiryAnnotation]
 	if !ok {
-		expiryString, ok = secret.Annotations[api.ServingCertExpiryAnnotation]
+		expiryString, ok = secret.Annotations[api.AlphaServingCertExpiryAnnotation]
 		if !ok {
 			return true, sharedService
 		}
@@ -136,9 +136,9 @@ func (sc *serviceServingCertUpdateController) requiresRegeneration(secret *v1.Se
 }
 
 func toServiceName(secret *v1.Secret) (string, bool) {
-	serviceName := secret.Annotations[api.BetaServiceNameAnnotation]
+	serviceName := secret.Annotations[api.ServiceNameAnnotation]
 	if len(serviceName) == 0 {
-		serviceName = secret.Annotations[api.ServiceNameAnnotation]
+		serviceName = secret.Annotations[api.AlphaServiceNameAnnotation]
 	}
 	return serviceName, len(serviceName) != 0
 }

--- a/pkg/controller/servingcert/controller/secret_updating_controller_test.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller_test.go
@@ -38,6 +38,193 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1", Name: "mysecret",
 					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation: "foo",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "service-uid-mismatch",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-2"), Annotations: map[string]string{api.AlphaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation: "foo",
+						api.AlphaServiceUIDAnnotation:  "uid-1",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-2")}})},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "service secret name mismatch",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.AlphaServingCertSecretAnnotation: "mysecret2"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation: "foo",
+						api.AlphaServiceUIDAnnotation:  "uid-1",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.AlphaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation: "foo",
+						api.AlphaServiceUIDAnnotation:  "uid-1",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "bad expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.AlphaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation:       "foo",
+						api.AlphaServiceUIDAnnotation:        "uid-1",
+						api.AlphaServingCertExpiryAnnotation: "bad-format",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "expired expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.AlphaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation:       "foo",
+						api.AlphaServiceUIDAnnotation:        "uid-1",
+						api.AlphaServingCertExpiryAnnotation: time.Now().Add(-30 * time.Minute).Format(time.RFC3339),
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "distant expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.AlphaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation:       "foo",
+						api.AlphaServiceUIDAnnotation:        "uid-1",
+						api.AlphaServingCertExpiryAnnotation: time.Now().Add(10 * time.Minute).Format(time.RFC3339),
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "missing ownerref",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.AlphaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.AlphaServiceNameAnnotation:       "foo",
+						api.AlphaServiceUIDAnnotation:        "uid-1",
+						api.AlphaServingCertExpiryAnnotation: time.Now().Add(10 * time.Minute).Format(time.RFC3339),
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-2")}})},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			c := &serviceServingCertUpdateController{
+				serviceLister: listers.NewServiceLister(index),
+			}
+			tc.primeServices(index)
+			actual, service := c.requiresRegeneration(tc.secret)
+			if tc.expected != actual {
+				t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, actual)
+			}
+			if service == nil && tc.expected {
+				t.Errorf("%s: should have returned service", tc.name)
+			}
+		})
+	}
+}
+
+func TestRequiresRegenerationServiceUIDMismatchBetaAnnotation(t *testing.T) {
+	tests := []struct {
+		name          string
+		primeServices func(cache.Indexer)
+		secret        *v1.Secret
+		expected      bool
+	}{
+		{
+			name:          "no service annotation",
+			primeServices: func(serviceCache cache.Indexer) {},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:          "missing service",
+			primeServices: func(serviceCache cache.Indexer) {},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
 						api.ServiceNameAnnotation: "foo",
 					},
 				},
@@ -175,193 +362,6 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 						api.ServiceNameAnnotation:       "foo",
 						api.ServiceUIDAnnotation:        "uid-1",
 						api.ServingCertExpiryAnnotation: time.Now().Add(10 * time.Minute).Format(time.RFC3339),
-					},
-					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-2")}})},
-				},
-			},
-			expected: true,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-			c := &serviceServingCertUpdateController{
-				serviceLister: listers.NewServiceLister(index),
-			}
-			tc.primeServices(index)
-			actual, service := c.requiresRegeneration(tc.secret)
-			if tc.expected != actual {
-				t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, actual)
-			}
-			if service == nil && tc.expected {
-				t.Errorf("%s: should have returned service", tc.name)
-			}
-		})
-	}
-}
-
-func TestRequiresRegenerationServiceUIDMismatchBetaAnnotation(t *testing.T) {
-	tests := []struct {
-		name          string
-		primeServices func(cache.Indexer)
-		secret        *v1.Secret
-		expected      bool
-	}{
-		{
-			name:          "no service annotation",
-			primeServices: func(serviceCache cache.Indexer) {},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{},
-				},
-			},
-			expected: false,
-		},
-		{
-			name:          "missing service",
-			primeServices: func(serviceCache cache.Indexer) {},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation: "foo",
-					},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "service-uid-mismatch",
-			primeServices: func(serviceCache cache.Indexer) {
-				serviceCache.Add(&v1.Service{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-2"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
-				})
-			},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation: "foo",
-						api.BetaServiceUIDAnnotation:  "uid-1",
-					},
-					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-2")}})},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "service secret name mismatch",
-			primeServices: func(serviceCache cache.Indexer) {
-				serviceCache.Add(&v1.Service{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret2"}},
-				})
-			},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation: "foo",
-						api.BetaServiceUIDAnnotation:  "uid-1",
-					},
-					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "no expiry",
-			primeServices: func(serviceCache cache.Indexer) {
-				serviceCache.Add(&v1.Service{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
-				})
-			},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation: "foo",
-						api.BetaServiceUIDAnnotation:  "uid-1",
-					},
-					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "bad expiry",
-			primeServices: func(serviceCache cache.Indexer) {
-				serviceCache.Add(&v1.Service{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
-				})
-			},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation:       "foo",
-						api.BetaServiceUIDAnnotation:        "uid-1",
-						api.BetaServingCertExpiryAnnotation: "bad-format",
-					},
-					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "expired expiry",
-			primeServices: func(serviceCache cache.Indexer) {
-				serviceCache.Add(&v1.Service{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
-				})
-			},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation:       "foo",
-						api.BetaServiceUIDAnnotation:        "uid-1",
-						api.BetaServingCertExpiryAnnotation: time.Now().Add(-30 * time.Minute).Format(time.RFC3339),
-					},
-					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "distant expiry",
-			primeServices: func(serviceCache cache.Indexer) {
-				serviceCache.Add(&v1.Service{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
-				})
-			},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation:       "foo",
-						api.BetaServiceUIDAnnotation:        "uid-1",
-						api.BetaServingCertExpiryAnnotation: time.Now().Add(10 * time.Minute).Format(time.RFC3339),
-					},
-					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
-				},
-			},
-			expected: false,
-		},
-		{
-			name: "missing ownerref",
-			primeServices: func(serviceCache cache.Indexer) {
-				serviceCache.Add(&v1.Service{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
-				})
-			},
-			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "ns1", Name: "mysecret",
-					Annotations: map[string]string{
-						api.BetaServiceNameAnnotation:       "foo",
-						api.BetaServiceUIDAnnotation:        "uid-1",
-						api.BetaServingCertExpiryAnnotation: time.Now().Add(10 * time.Minute).Format(time.RFC3339),
 					},
 					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-2")}})},
 				},

--- a/pkg/controller/servingcert/controller/secret_updating_controller_test.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller_test.go
@@ -199,3 +199,190 @@ func TestRequiresRegenerationServiceUIDMismatch(t *testing.T) {
 		})
 	}
 }
+
+func TestRequiresRegenerationServiceUIDMismatchBetaAnnotation(t *testing.T) {
+	tests := []struct {
+		name          string
+		primeServices func(cache.Indexer)
+		secret        *v1.Secret
+		expected      bool
+	}{
+		{
+			name:          "no service annotation",
+			primeServices: func(serviceCache cache.Indexer) {},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:          "missing service",
+			primeServices: func(serviceCache cache.Indexer) {},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation: "foo",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "service-uid-mismatch",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-2"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation: "foo",
+						api.BetaServiceUIDAnnotation:  "uid-1",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-2")}})},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "service secret name mismatch",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret2"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation: "foo",
+						api.BetaServiceUIDAnnotation:  "uid-1",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation: "foo",
+						api.BetaServiceUIDAnnotation:  "uid-1",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "bad expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation:       "foo",
+						api.BetaServiceUIDAnnotation:        "uid-1",
+						api.BetaServingCertExpiryAnnotation: "bad-format",
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "expired expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation:       "foo",
+						api.BetaServiceUIDAnnotation:        "uid-1",
+						api.BetaServingCertExpiryAnnotation: time.Now().Add(-30 * time.Minute).Format(time.RFC3339),
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "distant expiry",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation:       "foo",
+						api.BetaServiceUIDAnnotation:        "uid-1",
+						api.BetaServingCertExpiryAnnotation: time.Now().Add(10 * time.Minute).Format(time.RFC3339),
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-1")}})},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "missing ownerref",
+			primeServices: func(serviceCache cache.Indexer) {
+				serviceCache.Add(&v1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "foo", UID: types.UID("uid-1"), Annotations: map[string]string{api.BetaServingCertSecretAnnotation: "mysecret"}},
+				})
+			},
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1", Name: "mysecret",
+					Annotations: map[string]string{
+						api.BetaServiceNameAnnotation:       "foo",
+						api.BetaServiceUIDAnnotation:        "uid-1",
+						api.BetaServingCertExpiryAnnotation: time.Now().Add(10 * time.Minute).Format(time.RFC3339),
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef(&v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: types.UID("uid-2")}})},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			index := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			c := &serviceServingCertUpdateController{
+				serviceLister: listers.NewServiceLister(index),
+			}
+			tc.primeServices(index)
+			actual, service := c.requiresRegeneration(tc.secret)
+			if tc.expected != actual {
+				t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, actual)
+			}
+			if service == nil && tc.expected {
+				t.Errorf("%s: should have returned service", tc.name)
+			}
+		})
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -58,7 +58,7 @@ func createServingCertAnnotatedService(client *kubernetes.Clientset, secretName,
 		ObjectMeta: metav1.ObjectMeta{
 			Name: serviceName,
 			Annotations: map[string]string{
-				api.ServingCertSecretAnnotation: secretName,
+				api.AlphaServingCertSecretAnnotation: secretName,
 			},
 		},
 		Spec: v1.ServiceSpec{


### PR DESCRIPTION
This PR makes it so that `service.beta.openshift.io` variants of the annotations are honored, and both alpha and beta variants of the accounting annotations (errors, expiry, etc) are added to objects to make it easier to transition to beta completely. 
/cc @openshift/sig-auth 