### PR TITLE
refactor(bindata,sync): update configmap key to 'ca-bundle.crt'

### DIFF
--- a/bindata/v4.0.0/apiservice-cabundle-controller/defaultconfig.yaml
+++ b/bindata/v4.0.0/apiservice-cabundle-controller/defaultconfig.yaml
@@ -1,6 +1,6 @@
 apiVersion: servicecertsigner.config.openshift.io/v1alpha1
 kind: APIServiceCABundleInjectorConfig
-caBundleFile: /var/run/configmaps/signing-cabundle/cabundle.crt
+caBundleFile: /var/run/configmaps/signing-cabundle/ca-bundle.crt
 authentication:
   disabled: true
 authorization:

--- a/bindata/v4.0.0/apiservice-cabundle-controller/signing-cabundle.yaml
+++ b/bindata/v4.0.0/apiservice-cabundle-controller/signing-cabundle.yaml
@@ -4,4 +4,4 @@ metadata:
   namespace: openshift-service-cert-signer
   name: signing-cabundle
 data:
-  cabundle.crt:
+  ca-bundle.crt:

--- a/bindata/v4.0.0/configmap-cabundle-controller/defaultconfig.yaml
+++ b/bindata/v4.0.0/configmap-cabundle-controller/defaultconfig.yaml
@@ -1,6 +1,6 @@
 apiVersion: servicecertsigner.config.openshift.io/v1alpha1
 kind: ConfigMapCABundleInjectorConfig
-caBundleFile: /var/run/configmaps/signing-cabundle/cabundle.crt
+caBundleFile: /var/run/configmaps/signing-cabundle/ca-bundle.crt
 authentication:
   disabled: true
 authorization:

--- a/bindata/v4.0.0/configmap-cabundle-controller/signing-cabundle.yaml
+++ b/bindata/v4.0.0/configmap-cabundle-controller/signing-cabundle.yaml
@@ -4,4 +4,4 @@ metadata:
   namespace: openshift-service-cert-signer
   name: signing-cabundle
 data:
-  cabundle.crt:
+  ca-bundle.crt:

--- a/pkg/operator/sync_apiservice_v4_00.go
+++ b/pkg/operator/sync_apiservice_v4_00.go
@@ -128,7 +128,7 @@ func manageSigningCABundle(client coreclientv1.CoreV1Interface, eventRecorder ev
 		return existing, false, err
 	}
 
-	configMap.Data["cabundle.crt"] = string(currentSigningKeySecret.Data["tls.crt"])
+	configMap.Data["ca-bundle.crt"] = string(currentSigningKeySecret.Data["tls.crt"])
 
 	return resourceapply.ApplyConfigMap(client, eventRecorder, configMap)
 }

--- a/pkg/operator/sync_configmapcabundle_v4_00.go
+++ b/pkg/operator/sync_configmapcabundle_v4_00.go
@@ -123,7 +123,7 @@ func manageConfigMapCABundle(client coreclientv1.CoreV1Interface, eventRecorder 
 		return existing, false, err
 	}
 
-	configMap.Data["cabundle.crt"] = string(currentSigningKeySecret.Data["tls.crt"])
+	configMap.Data["ca-bundle.crt"] = string(currentSigningKeySecret.Data["tls.crt"])
 
 	return resourceapply.ApplyConfigMap(client, eventRecorder, configMap)
 }

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -160,7 +160,7 @@ func v400ApiserviceCabundleControllerCmYaml() (*asset, error) {
 
 var _v400ApiserviceCabundleControllerDefaultconfigYaml = []byte(`apiVersion: servicecertsigner.config.openshift.io/v1alpha1
 kind: APIServiceCABundleInjectorConfig
-caBundleFile: /var/run/configmaps/signing-cabundle/cabundle.crt
+caBundleFile: /var/run/configmaps/signing-cabundle/ca-bundle.crt
 authentication:
   disabled: true
 authorization:
@@ -382,7 +382,7 @@ metadata:
   namespace: openshift-service-cert-signer
   name: signing-cabundle
 data:
-  cabundle.crt:
+  ca-bundle.crt:
 `)
 
 func v400ApiserviceCabundleControllerSigningCabundleYamlBytes() ([]byte, error) {
@@ -485,7 +485,7 @@ func v400ConfigmapCabundleControllerCmYaml() (*asset, error) {
 
 var _v400ConfigmapCabundleControllerDefaultconfigYaml = []byte(`apiVersion: servicecertsigner.config.openshift.io/v1alpha1
 kind: ConfigMapCABundleInjectorConfig
-caBundleFile: /var/run/configmaps/signing-cabundle/cabundle.crt
+caBundleFile: /var/run/configmaps/signing-cabundle/ca-bundle.crt
 authentication:
   disabled: true
 authorization:
@@ -708,7 +708,7 @@ metadata:
   namespace: openshift-service-cert-signer
   name: signing-cabundle
 data:
-  cabundle.crt:
+  ca-bundle.crt:
 `)
 
 func v400ConfigmapCabundleControllerSigningCabundleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Be consistent with other components and use the key 'ca-bundle.crt'
instead of 'cabundle.crt' for CA bundle data in configmaps.