### PR TITLE
manifests: Rename origin-service-ca -> origin-service-ca-operator

### DIFF
--- a/manifests/0000_09_service-ca-operator_05_deploy.yaml
+++ b/manifests/0000_09_service-ca-operator_05_deploy.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: openshift-service-ca-operator
       containers:
       - name: operator
-        image: quay.io/openshift/origin-service-ca:v4.0
+        image: quay.io/openshift/origin-service-ca-operator:v4.0
         imagePullPolicy: IfNotPresent
         command: ["service-ca-operator", "operator"]
         args:
@@ -27,7 +27,7 @@ spec:
         - "-v=4"
         env:
         - name: CONTROLLER_IMAGE
-          value: quay.io/openshift/origin-service-ca:v4.0
+          value: quay.io/openshift/origin-service-ca-operator:v4.0
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -2,7 +2,7 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: service-ca
+  - name: service-ca-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-service-ca:v4.0
+      name: quay.io/openshift/origin-service-ca-operator:v4.0


### PR DESCRIPTION
This is what ART is looking for:

```console
$ oc adm release new --from-image-stream=4.0-art-latest -n ocp --to-dir=/tmp/release --reference-mode=source
info: Found 141 images in image stream
...
Loading manifests from service-ca-operator: sha256:4fa49d7b421f5bb5fed9d99de71338fbbd0be5613645bff1353069da1400443d ...
info: Included 73 referenced images into the payload
error: unable to create a release: operator "service-ca-operator" failed to map images: image file "/tmp/release-image-0.0.1-2019-03-12-222249977939869/service-ca-operator/image-references" referenced image "service-ca" that is not part of the input images
```

and while we don't know how to fix ART to look for the service-ca name, we do know how to adjust the name here ;).