### PR TITLE
fix crd yaml

### DIFF
--- a/manifests/0000_09_service-ca-operator_02_crd.yaml
+++ b/manifests/0000_09_service-ca-operator_02_crd.yaml
@@ -3,12 +3,13 @@ kind: CustomResourceDefinition
 metadata:
   name: servicecas.operator.openshift.io
 spec:
+  scope: Cluster
   group: operator.openshift.io
+  version: v1
   names:
     kind: ServiceCA
     plural: servicecas
     singular: serviceca
-  scope: Cluster
   validation:
     openAPIV3Schema:
       properties:
@@ -92,10 +93,3 @@ spec:
           type: object
         status:
           type: object
-  version: v1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
@enj the status was accidentally merged in with the validation.  Similar to here: https://github.com/openshift/cluster-authentication-operator/pull/80#discussion_r262357196