### PR TITLE
[WIP] Fix regeneration of secrets and configmaps upon CA refresh

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/service-ca-operator/pkg/boilerplate/operator"
 	"github.com/openshift/service-ca-operator/pkg/controller/api"
 	"github.com/openshift/service-ca-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/crypto"
 )
 
 type serviceCAOperator struct {
@@ -32,6 +33,8 @@ type serviceCAOperator struct {
 
 	versionGetter status.VersionGetter
 	eventRecorder events.Recorder
+
+	ca         *crypto.CA
 }
 
 func NewServiceCAOperator(

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -26,12 +26,12 @@ func syncControllers(c serviceCAOperator, operatorConfig *operatorv1.ServiceCA) 
 	}
 
 	// Sync the CA (regenerate if missing).
-	_, modified, err = manageSignerCA(c.corev1Client, c.eventRecorder)
+	_, modified, err = manageSignerCA(c)
 	if err != nil {
 		return fmt.Errorf("Error syncing signer CA: %v", err)
 	}
 	// Sync the CA bundle. This will be updated if the CA has changed.
-	_, modified, err = manageSignerCABundle(c.corev1Client, c.eventRecorder)
+	_, modified, err = manageSignerCABundle(c)
 	if err != nil {
 		return fmt.Errorf("Error syncing signer CA bundle: %v", err)
 	}


### PR DESCRIPTION
First add a CA cache to the operator used during sync, which I think will help with the regeneration process if you update the signing key secret with a CA and key generated outside of the operator, but I need to test. Also contains debugging lines and tests are to come.