### PR TITLE
Improve/fix version,status reporting for service-ca clusteroperator

### DIFF
--- a/pkg/operator/operatorclient/operatorclient.go
+++ b/pkg/operator/operatorclient/operatorclient.go
@@ -6,6 +6,8 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions"
+
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
 
 type OperatorClient struct {
@@ -16,8 +18,9 @@ type OperatorClient struct {
 func (c *OperatorClient) Informer() cache.SharedIndexInformer {
 	return c.Informers.Operator().V1().ServiceCAs().Informer()
 }
+
 func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
-	instance, err := c.Informers.Operator().V1().ServiceCAs().Lister().Get("cluster")
+	instance, err := c.Informers.Operator().V1().ServiceCAs().Lister().Get(api.OperatorConfigInstanceName)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -26,7 +29,7 @@ func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operator
 }
 
 func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
-	original, err := c.Informers.Operator().V1().ServiceCAs().Lister().Get("cluster")
+	original, err := c.Informers.Operator().V1().ServiceCAs().Lister().Get(api.OperatorConfigInstanceName)
 	if err != nil {
 		return nil, "", err
 	}
@@ -42,7 +45,7 @@ func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operat
 	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
 }
 func (c *OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
-	original, err := c.Informers.Operator().V1().ServiceCAs().Lister().Get("cluster")
+	original, err := c.Informers.Operator().V1().ServiceCAs().Lister().Get(api.OperatorConfigInstanceName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Switch to using library-go/operator v1helpers.UpdateStatus and other improvements in status reporting

Summary of status reporting (3 deployments == configmap-cabundle-injector, apiservice-cabundle-injector, and serving-cert-signer) :
```
Available=True | VersionUpdate=True | Progressing=False
* All replicas of each of the 3 deployments is running
* No instances running from previous deployments

Available=True | VersionUpdate=True | Progressing=True
* At least 1 replica of each of the 3 deployments is running
* No instances running from previous deployments
* Not all replicas of each of the 3 deployments exist, still deploying

Available=True | VersionUpdate=False | Progressing=True
* At least 1 replica of each of the 3 deployments is running
* Instances found running from previous deployments

Available=False 
* At least 1 replica of any of the 3 deployments is not running

Progressing=True
* IsNotFound error any 1 of deployments
* Found DeletionTimestamp for any deployment
* A deployment does not have an available replica
* A deployment does not have it’s configured available replicas

Failing=True
* Error returned from syncLoop
* Error in fetching deployments (but not IsNotFound error)
```

There is a ~10 second gap in version reporting of service-ca CO during upgrades.
 [this](https://github.com/openshift/library-go/pull/319) fixes the gap in version reporting
Bumping deps here: https://github.com/openshift/service-ca-operator/pull/40