### PR TITLE
Allow deletion of signing key secret for CA regeneration

### DIFF
--- a/bindata/v4.0.0/apiservice-cabundle-controller/defaultconfig.yaml
+++ b/bindata/v4.0.0/apiservice-cabundle-controller/defaultconfig.yaml
@@ -5,3 +5,7 @@ authentication:
   disabled: true
 authorization:
   disabled: true
+leaderElection:
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"

--- a/bindata/v4.0.0/configmap-cabundle-controller/defaultconfig.yaml
+++ b/bindata/v4.0.0/configmap-cabundle-controller/defaultconfig.yaml
@@ -5,3 +5,7 @@ authentication:
   disabled: true
 authorization:
   disabled: true
+leaderElection:
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"

--- a/bindata/v4.0.0/service-serving-cert-signer-controller/defaultconfig.yaml
+++ b/bindata/v4.0.0/service-serving-cert-signer-controller/defaultconfig.yaml
@@ -7,3 +7,7 @@ authentication:
   disabled: true
 authorization:
   disabled: true
+leaderElection:
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"

--- a/pkg/boilerplate/controller/filter.go
+++ b/pkg/boilerplate/controller/filter.go
@@ -1,52 +1,52 @@
 package controller
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type ParentFilter interface {
-	Parent(obj v1.Object) (namespace, name string)
+	Parent(obj metav1.Object) (namespace, name string)
 	Filter
 }
 
 type Filter interface {
-	Add(obj v1.Object) bool
-	Update(oldObj, newObj v1.Object) bool
-	Delete(obj v1.Object) bool
+	Add(obj metav1.Object) bool
+	Update(oldObj, newObj metav1.Object) bool
+	Delete(obj metav1.Object) bool
 }
 
-type ParentFunc func(obj v1.Object) (namespace, name string)
+type ParentFunc func(obj metav1.Object) (namespace, name string)
 
 type FilterFuncs struct {
 	ParentFunc ParentFunc
-	AddFunc    func(obj v1.Object) bool
-	UpdateFunc func(oldObj, newObj v1.Object) bool
-	DeleteFunc func(obj v1.Object) bool
+	AddFunc    func(obj metav1.Object) bool
+	UpdateFunc func(oldObj, newObj metav1.Object) bool
+	DeleteFunc func(obj metav1.Object) bool
 }
 
-func (f FilterFuncs) Parent(obj v1.Object) (namespace, name string) {
+func (f FilterFuncs) Parent(obj metav1.Object) (namespace, name string) {
 	if f.ParentFunc == nil {
 		return obj.GetNamespace(), obj.GetName()
 	}
 	return f.ParentFunc(obj)
 }
 
-func (f FilterFuncs) Add(obj v1.Object) bool {
+func (f FilterFuncs) Add(obj metav1.Object) bool {
 	if f.AddFunc == nil {
 		return false
 	}
 	return f.AddFunc(obj)
 }
 
-func (f FilterFuncs) Update(oldObj, newObj v1.Object) bool {
+func (f FilterFuncs) Update(oldObj, newObj metav1.Object) bool {
 	if f.UpdateFunc == nil {
 		return false
 	}
 	return f.UpdateFunc(oldObj, newObj)
 }
 
-func (f FilterFuncs) Delete(obj v1.Object) bool {
+func (f FilterFuncs) Delete(obj metav1.Object) bool {
 	if f.DeleteFunc == nil {
 		return false
 	}
@@ -55,13 +55,13 @@ func (f FilterFuncs) Delete(obj v1.Object) bool {
 
 func FilterByNames(parentFunc ParentFunc, names ...string) ParentFilter {
 	set := sets.NewString(names...)
-	has := func(obj v1.Object) bool {
+	has := func(obj metav1.Object) bool {
 		return set.Has(obj.GetName())
 	}
 	return FilterFuncs{
 		ParentFunc: parentFunc,
 		AddFunc:    has,
-		UpdateFunc: func(oldObj, newObj v1.Object) bool {
+		UpdateFunc: func(oldObj, newObj metav1.Object) bool {
 			return has(newObj)
 		},
 		DeleteFunc: has,

--- a/pkg/controller/configmapcainjector/controller/configmap_injecting_controller.go
+++ b/pkg/controller/configmapcainjector/controller/configmap_injecting_controller.go
@@ -1,8 +1,10 @@
 package controller
 
 import (
+	"github.com/golang/glog"
+
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	informers "k8s.io/client-go/informers/core/v1"
 	kcoreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 	listers "k8s.io/client-go/listers/core/v1"
@@ -35,11 +37,11 @@ func NewConfigMapCABundleInjectionController(configMaps informers.ConfigMapInfor
 	)
 }
 
-func (ic *configMapCABundleInjectionController) Key(namespace, name string) (v1.Object, error) {
+func (ic *configMapCABundleInjectionController) Key(namespace, name string) (metav1.Object, error) {
 	return ic.configMapLister.ConfigMaps(namespace).Get(name)
 }
 
-func (ic *configMapCABundleInjectionController) Sync(obj v1.Object) error {
+func (ic *configMapCABundleInjectionController) Sync(obj metav1.Object) error {
 	sharedConfigMap := obj.(*corev1.ConfigMap)
 
 	// check if we need to do anything
@@ -61,6 +63,7 @@ func (ic *configMapCABundleInjectionController) ensureConfigMapCABundleInjection
 	// make a copy to avoid mutating cache state
 	configMapCopy := current.DeepCopy()
 	configMapCopy.Data = map[string]string{api.InjectionDataKey: ic.ca}
+	glog.V(4).Infof("updating configmap %s/%s with CA", configMapCopy.GetNamespace(), configMapCopy.GetName())
 	_, err := ic.configMapClient.ConfigMaps(current.Namespace).Update(configMapCopy)
 	return err
 }

--- a/pkg/controller/servingcert/controller/secret_creating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller.go
@@ -1,14 +1,13 @@
 package controller
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/golang/glog"
 
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -70,7 +69,7 @@ func NewServiceServingCertController(services informers.ServiceInformer, secrets
 		}),
 		controller.WithInformer(secrets, controller.FilterFuncs{
 			ParentFunc: func(obj metav1.Object) (namespace, name string) {
-				secret := obj.(*v1.Secret)
+				secret := obj.(*corev1.Secret)
 				serviceName, _ := toServiceName(secret)
 				return secret.Namespace, serviceName
 			},
@@ -84,7 +83,7 @@ func NewServiceServingCertController(services informers.ServiceInformer, secrets
 // deleteSecret handles the case when the service certificate secret is manually removed.
 // In that case the secret will be automatically recreated.
 func (sc *serviceServingCertController) deleteSecret(obj metav1.Object) bool {
-	secret := obj.(*v1.Secret)
+	secret := obj.(*corev1.Secret)
 	serviceName, ok := toServiceName(secret)
 	if !ok {
 		return false
@@ -111,7 +110,7 @@ func (sc *serviceServingCertController) Sync(obj metav1.Object) error {
 }
 
 func (sc *serviceServingCertController) syncService(obj metav1.Object) error {
-	sharedService := obj.(*v1.Service)
+	sharedService := obj.(*corev1.Service)
 
 	if !sc.requiresCertGeneration(sharedService) {
 		return nil
@@ -122,7 +121,8 @@ func (sc *serviceServingCertController) syncService(obj metav1.Object) error {
 	return sc.generateCert(serviceCopy)
 }
 
-func (sc *serviceServingCertController) generateCert(serviceCopy *v1.Service) error {
+func (sc *serviceServingCertController) generateCert(serviceCopy *corev1.Service) error {
+	glog.V(4).Infof("generating new cert for %s/%s", serviceCopy.GetNamespace(), serviceCopy.GetName())
 	if serviceCopy.Annotations == nil {
 		serviceCopy.Annotations = map[string]string{}
 	}
@@ -134,69 +134,33 @@ func (sc *serviceServingCertController) generateCert(serviceCopy *v1.Service) er
 
 	_, err := sc.secretClient.Secrets(serviceCopy.Namespace).Create(secret)
 	if err != nil && !kapierrors.IsAlreadyExists(err) {
-		// if we have an error creating the secret, then try to update the service with that information.  If it fails,
-		// then we'll just try again later on re-list or because the service had already been updated and we'll get triggered again.
-		serviceCopy.Annotations[api.ServingCertErrorAnnotation] = err.Error()
-		serviceCopy.Annotations[api.AlphaServingCertErrorAnnotation] = err.Error()
-		numFailure := strconv.Itoa(getNumFailures(serviceCopy) + 1)
-		serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = numFailure
-		serviceCopy.Annotations[api.AlphaServingCertErrorNumAnnotation] = numFailure
-		_, updateErr := sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
-
-		// if we're past the max retries and we successfully updated, then the sync loop successfully handled this service and we want to forget it
-		if updateErr == nil && getNumFailures(serviceCopy) >= sc.maxRetries {
-			return nil
-		}
-		return err
+		return sc.updateServiceFailure(serviceCopy, err)
 	}
 	if kapierrors.IsAlreadyExists(err) {
 		actualSecret, err := sc.secretClient.Secrets(serviceCopy.Namespace).Get(secret.Name, metav1.GetOptions{})
 		if err != nil {
-			// if we have an error creating the secret, then try to update the service with that information.  If it fails,
-			// then we'll just try again later on  re-list or because the service had already been updated and we'll get triggered again.
-			serviceCopy.Annotations[api.ServingCertErrorAnnotation] = err.Error()
-			serviceCopy.Annotations[api.AlphaServingCertErrorAnnotation] = err.Error()
-			numFailure := strconv.Itoa(getNumFailures(serviceCopy) + 1)
-			serviceCopy.Annotations[api.AlphaServingCertErrorNumAnnotation] = numFailure
-			serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = numFailure
-			_, updateErr := sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
-
-			// if we're past the max retries and we successfully updated, then the sync loop successfully handled this service and we want to forget it
-			if updateErr == nil && getNumFailures(serviceCopy) >= sc.maxRetries {
-				return nil
-			}
-			return err
+			return sc.updateServiceFailure(serviceCopy, err)
 		}
 
-		if (actualSecret.Annotations[api.AlphaServiceUIDAnnotation] != string(serviceCopy.UID)) && (actualSecret.Annotations[api.ServiceUIDAnnotation] != string(serviceCopy.UID)) {
-			serviceCopy.Annotations[api.AlphaServingCertErrorAnnotation] = fmt.Sprintf("secret/%v references serviceUID %v, which does not match %v", actualSecret.Name, actualSecret.Annotations[api.AlphaServiceUIDAnnotation], serviceCopy.UID)
-			serviceCopy.Annotations[api.ServingCertErrorAnnotation] = fmt.Sprintf("secret/%v references serviceUID %v, which does not match %v", actualSecret.Name, actualSecret.Annotations[api.ServiceUIDAnnotation], serviceCopy.UID)
-			numFailure := strconv.Itoa(getNumFailures(serviceCopy) + 1)
-			serviceCopy.Annotations[api.ServingCertErrorNumAnnotation] = numFailure
-			serviceCopy.Annotations[api.AlphaServingCertErrorNumAnnotation] = numFailure
-			_, updateErr := sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
-
-			// if we're past the max retries and we successfully updated, then the sync loop successfully handled this service and we want to forget it
-			if updateErr == nil && getNumFailures(serviceCopy) >= sc.maxRetries {
-				return nil
-			}
-			// TODO: Return ServingCertErrorAnnotation when removing alpha annotations.
-			return errors.New(serviceCopy.Annotations[api.AlphaServingCertErrorAnnotation])
+		if !uidsEqual(actualSecret, serviceCopy) {
+			uidErr := fmt.Errorf("secret %s/%s does not have corresponding service UID %v", actualSecret.GetNamespace(), actualSecret.GetName(), serviceCopy.UID)
+			return sc.updateServiceFailure(serviceCopy, uidErr)
+		}
+		glog.V(4).Infof("renewing cert in existing secret %s/%s", secret.GetNamespace(), secret.GetName())
+		// Actually update the secret in the regeneration case (the secret already exists but we want to update to a new cert).
+		_, updateErr := sc.secretClient.Secrets(secret.GetNamespace()).Update(secret)
+		if updateErr != nil {
+			return sc.updateServiceFailure(serviceCopy, updateErr)
 		}
 	}
 
-	serviceCopy.Annotations[api.AlphaServingCertCreatedByAnnotation] = sc.commonName()
-	serviceCopy.Annotations[api.ServingCertCreatedByAnnotation] = sc.commonName()
-	delete(serviceCopy.Annotations, api.AlphaServingCertErrorAnnotation)
-	delete(serviceCopy.Annotations, api.AlphaServingCertErrorNumAnnotation)
-	delete(serviceCopy.Annotations, api.ServingCertErrorAnnotation)
-	delete(serviceCopy.Annotations, api.ServingCertErrorNumAnnotation)
+	sc.resetServiceAnnotations(serviceCopy)
 	_, err = sc.serviceClient.Services(serviceCopy.Namespace).Update(serviceCopy)
 
 	return err
 }
 
-func getNumFailures(service *v1.Service) int {
+func getNumFailures(service *corev1.Service) int {
 	numFailuresString := service.Annotations[api.ServingCertErrorNumAnnotation]
 	if len(numFailuresString) == 0 {
 		numFailuresString = service.Annotations[api.AlphaServingCertErrorNumAnnotation]
@@ -213,7 +177,7 @@ func getNumFailures(service *v1.Service) int {
 	return numFailures
 }
 
-func (sc *serviceServingCertController) requiresCertGeneration(service *v1.Service) bool {
+func (sc *serviceServingCertController) requiresCertGeneration(service *corev1.Service) bool {
 	// check the secret since it could not have been created yet
 	secretName := service.Annotations[api.ServingCertSecretAnnotation]
 	if len(secretName) == 0 {
@@ -251,7 +215,36 @@ func (sc *serviceServingCertController) commonName() string {
 	return sc.ca.Config.Certs[0].Subject.CommonName
 }
 
-func ownerRef(service *v1.Service) metav1.OwnerReference {
+// updateServiceFailure updates the service's error annotations with err.
+// Returns the passed in err normally, or nil if the amount of failures has hit the max. This is so it can act as a
+// return to the sync method.
+func (sc *serviceServingCertController) updateServiceFailure(service *corev1.Service, err error) error {
+	setErrAnnotation(service, err)
+	incrementFailureNumAnnotation(service)
+	_, updateErr := sc.serviceClient.Services(service.Namespace).Update(service)
+	if updateErr != nil {
+		glog.V(4).Infof("warning: failed to update failure annotations on service %s: %v", service.Name, updateErr)
+	}
+	// Past the max retries means we've handled this failure enough, so forget it from the queue.
+	if updateErr == nil && getNumFailures(service) >= sc.maxRetries {
+		return nil
+	}
+
+	// Return the original error.
+	return err
+}
+
+// Sets the service CA common name and clears any errors.
+func (sc *serviceServingCertController) resetServiceAnnotations(service *corev1.Service) {
+	service.Annotations[api.AlphaServingCertCreatedByAnnotation] = sc.commonName()
+	service.Annotations[api.ServingCertCreatedByAnnotation] = sc.commonName()
+	delete(service.Annotations, api.AlphaServingCertErrorAnnotation)
+	delete(service.Annotations, api.AlphaServingCertErrorNumAnnotation)
+	delete(service.Annotations, api.ServingCertErrorAnnotation)
+	delete(service.Annotations, api.ServingCertErrorNumAnnotation)
+}
+
+func ownerRef(service *corev1.Service) metav1.OwnerReference {
 	return metav1.OwnerReference{
 		APIVersion: "v1",
 		Kind:       "Service",
@@ -260,10 +253,10 @@ func ownerRef(service *v1.Service) metav1.OwnerReference {
 	}
 }
 
-func toBaseSecret(service *v1.Service) *v1.Secret {
+func toBaseSecret(service *corev1.Service) *corev1.Secret {
 	// Use beta annotations
 	if _, ok := service.Annotations[api.ServingCertSecretAnnotation]; ok {
-		return &v1.Secret{
+		return &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      service.Annotations[api.ServingCertSecretAnnotation],
 				Namespace: service.Namespace,
@@ -272,11 +265,11 @@ func toBaseSecret(service *v1.Service) *v1.Secret {
 					api.ServiceNameAnnotation: service.Name,
 				},
 			},
-			Type: v1.SecretTypeTLS,
+			Type: corev1.SecretTypeTLS,
 		}
 	}
 	// Use alpha annotations
-	return &v1.Secret{
+	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      service.Annotations[api.AlphaServingCertSecretAnnotation],
 			Namespace: service.Namespace,
@@ -285,10 +278,11 @@ func toBaseSecret(service *v1.Service) *v1.Secret {
 				api.AlphaServiceNameAnnotation: service.Name,
 			},
 		},
-		Type: v1.SecretTypeTLS,
+		Type: corev1.SecretTypeTLS,
 	}
 }
-func getServingCert(dnsSuffix string, ca *crypto.CA, service *v1.Service) (*crypto.TLSCertificateConfig, error) {
+
+func getServingCert(dnsSuffix string, ca *crypto.CA, service *corev1.Service) (*crypto.TLSCertificateConfig, error) {
 	dnsName := service.Name + "." + service.Namespace + ".svc"
 	fqDNSName := dnsName + "." + dnsSuffix
 	certificateLifetime := 365 * 2 // 2 years
@@ -303,7 +297,7 @@ func getServingCert(dnsSuffix string, ca *crypto.CA, service *v1.Service) (*cryp
 	return servingCert, nil
 }
 
-func toRequiredSecret(dnsSuffix string, ca *crypto.CA, service *v1.Service, secretCopy *v1.Secret) error {
+func toRequiredSecret(dnsSuffix string, ca *crypto.CA, service *corev1.Service, secretCopy *corev1.Secret) error {
 	servingCert, err := getServingCert(dnsSuffix, ca, service)
 	if err != nil {
 		return err
@@ -317,8 +311,8 @@ func toRequiredSecret(dnsSuffix string, ca *crypto.CA, service *v1.Service, secr
 	}
 	// let garbage collector cleanup map allocation, for simplicity
 	secretCopy.Data = map[string][]byte{
-		v1.TLSCertKey:       certBytes,
-		v1.TLSPrivateKeyKey: keyBytes,
+		corev1.TLSCertKey:       certBytes,
+		corev1.TLSPrivateKeyKey: keyBytes,
 	}
 
 	secretCopy.Annotations[api.AlphaServingCertExpiryAnnotation] = servingCert.Certs[0].NotAfter.Format(time.RFC3339)
@@ -327,4 +321,21 @@ func toRequiredSecret(dnsSuffix string, ca *crypto.CA, service *v1.Service, secr
 	ocontroller.EnsureOwnerRef(secretCopy, ownerRef(service))
 
 	return nil
+}
+
+func setErrAnnotation(service *corev1.Service, err error) {
+	service.Annotations[api.ServingCertErrorAnnotation] = err.Error()
+	service.Annotations[api.AlphaServingCertErrorAnnotation] = err.Error()
+}
+
+func incrementFailureNumAnnotation(service *corev1.Service) {
+	numFailure := strconv.Itoa(getNumFailures(service) + 1)
+	service.Annotations[api.ServingCertErrorNumAnnotation] = numFailure
+	service.Annotations[api.AlphaServingCertErrorNumAnnotation] = numFailure
+}
+
+func uidsEqual(secret *corev1.Secret, service *corev1.Service) bool {
+	suid := string(service.UID)
+	return secret.Annotations[api.AlphaServiceUIDAnnotation] == suid ||
+		secret.Annotations[api.ServiceUIDAnnotation] == suid
 }

--- a/pkg/controller/servingcert/controller/secret_creating_controller_test.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -466,7 +466,7 @@ func TestAlreadyExistingSecretForDifferentUIDControllerFlow(t *testing.T) {
 	defer close(stopChannel)
 	received := make(chan bool)
 
-	expectedError := "secret/new-secret references serviceUID wrong-uid, which does not match some-uid"
+	expectedError := "secret ns/new-secret does not have corresponding service UID some-uid"
 	expectedSecretName := "new-secret"
 	serviceName := "svc-name"
 	serviceUID := "some-uid"
@@ -553,7 +553,7 @@ func TestAlreadyExistingSecretForDifferentUIDControllerFlowBetaAnnotation(t *tes
 	defer close(stopChannel)
 	received := make(chan bool)
 
-	expectedError := "secret/new-secret references serviceUID wrong-uid, which does not match some-uid"
+	expectedError := "secret ns/new-secret does not have corresponding service UID some-uid"
 	expectedSecretName := "new-secret"
 	serviceName := "svc-name"
 	serviceUID := "some-uid"

--- a/pkg/operator/sync_common.go
+++ b/pkg/operator/sync_common.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
+	"github.com/golang/glog"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
-	"github.com/openshift/service-ca-operator/pkg/operator/operatorclient"
 	"github.com/openshift/service-ca-operator/pkg/operator/v4_00_assets"
 )
 
@@ -28,145 +27,166 @@ func manageControllerNS(c serviceCAOperator) (bool, error) {
 	return modified, err
 }
 
-func manageSignerControllerResources(c serviceCAOperator) (bool, string) {
-	return manageControllerResources(c, "v4.0.0/service-serving-cert-signer-controller/")
+func manageSignerControllerResources(c serviceCAOperator, modified *bool) error {
+	return manageControllerResources(c, "v4.0.0/service-serving-cert-signer-controller/", modified)
 }
 
-func manageAPIServiceControllerResources(c serviceCAOperator) (bool, string) {
-	return manageControllerResources(c, "v4.0.0/apiservice-cabundle-controller/")
+func manageAPIServiceControllerResources(c serviceCAOperator, modified *bool) error {
+	return manageControllerResources(c, "v4.0.0/apiservice-cabundle-controller/", modified)
 }
 
-func manageConfigMapCABundleControllerResources(c serviceCAOperator) (bool, string) {
-	return manageControllerResources(c, "v4.0.0/configmap-cabundle-controller/")
+func manageConfigMapCABundleControllerResources(c serviceCAOperator, modified *bool) error {
+	return manageControllerResources(c, "v4.0.0/configmap-cabundle-controller/", modified)
 }
 
-func manageControllerResources(c serviceCAOperator, resourcePath string) (bool, string) {
+func manageControllerResources(c serviceCAOperator, resourcePath string, modified *bool) error {
 	var err error
 	requiredClusterRole := resourceread.ReadClusterRoleV1OrDie(v4_00_assets.MustAsset(resourcePath + "clusterrole.yaml"))
-	_, _, err = resourceapply.ApplyClusterRole(c.rbacv1Client, c.eventRecorder, requiredClusterRole)
+	_, mod, err := resourceapply.ApplyClusterRole(c.rbacv1Client, c.eventRecorder, requiredClusterRole)
 	if err != nil {
-		return false, "clusterrole"
+		return err
 	}
+	*modified = *modified || mod
 
 	requiredClusterRoleBinding := resourceread.ReadClusterRoleBindingV1OrDie(v4_00_assets.MustAsset(resourcePath + "clusterrolebinding.yaml"))
-	_, _, err = resourceapply.ApplyClusterRoleBinding(c.rbacv1Client, c.eventRecorder, requiredClusterRoleBinding)
+	_, mod, err = resourceapply.ApplyClusterRoleBinding(c.rbacv1Client, c.eventRecorder, requiredClusterRoleBinding)
 	if err != nil {
-		return false, "clusterrolebinding"
+		return err
 	}
+	*modified = *modified || mod
 
 	requiredRole := resourceread.ReadRoleV1OrDie(v4_00_assets.MustAsset(resourcePath + "role.yaml"))
-	_, _, err = resourceapply.ApplyRole(c.rbacv1Client, c.eventRecorder, requiredRole)
+	_, mod, err = resourceapply.ApplyRole(c.rbacv1Client, c.eventRecorder, requiredRole)
 	if err != nil {
-		return false, "role"
+		return err
 	}
+	*modified = *modified || mod
 
 	requiredRoleBinding := resourceread.ReadRoleBindingV1OrDie(v4_00_assets.MustAsset(resourcePath + "rolebinding.yaml"))
-	_, _, err = resourceapply.ApplyRoleBinding(c.rbacv1Client, c.eventRecorder, requiredRoleBinding)
+	_, mod, err = resourceapply.ApplyRoleBinding(c.rbacv1Client, c.eventRecorder, requiredRoleBinding)
 	if err != nil {
-		return false, "rolebinding"
+		return err
 	}
+	*modified = *modified || mod
 
 	requiredSA := resourceread.ReadServiceAccountV1OrDie(v4_00_assets.MustAsset(resourcePath + "sa.yaml"))
-	_, saModified, err := resourceapply.ApplyServiceAccount(c.corev1Client, c.eventRecorder, requiredSA)
+	_, mod, err = resourceapply.ApplyServiceAccount(c.corev1Client, c.eventRecorder, requiredSA)
 	if err != nil {
-		return false, "serviceaccount"
+		return err
 	}
+	*modified = *modified || mod
 
-	return saModified, ""
+	return nil
 }
 
 // TODO manage rotation in addition to initial creation
-func manageSignerCA(client coreclientv1.SecretsGetter, eventRecorder events.Recorder) (*corev1.Secret, bool, error) {
+func manageSignerCA(client coreclientv1.SecretsGetter, eventRecorder events.Recorder) (bool, error) {
 	secret := resourceread.ReadSecretV1OrDie(v4_00_assets.MustAsset("v4.0.0/service-serving-cert-signer-controller/signing-secret.yaml"))
-	existing, err := client.Secrets(secret.Namespace).Get(secret.Name, metav1.GetOptions{})
+	_, err := client.Secrets(secret.Namespace).Get(secret.Name, metav1.GetOptions{})
 	if !apierrors.IsNotFound(err) {
-		return existing, false, err
+		return false, err
 	}
+	name := serviceServingCertSignerName()
+	glog.V(4).Infof("generating signing CA: %s", name)
 
-	ca, err := crypto.MakeSelfSignedCAConfig(serviceServingCertSignerName(), 365)
+	ca, err := crypto.MakeSelfSignedCAConfig(name, 365)
 	if err != nil {
-		return existing, false, err
+		return false, err
 	}
 
 	certBytes := &bytes.Buffer{}
 	keyBytes := &bytes.Buffer{}
 	if err := ca.WriteCertConfig(certBytes, keyBytes); err != nil {
-		return existing, false, err
+		return false, err
 	}
 
 	secret.Data["tls.crt"] = certBytes.Bytes()
 	secret.Data["tls.key"] = keyBytes.Bytes()
-
-	return resourceapply.ApplySecret(client, eventRecorder, secret)
+	_, mod, err := resourceapply.ApplySecret(client, eventRecorder, secret)
+	return mod, err
 }
 
-// TODO manage rotation in addition to initial creation
-func manageSignerCABundle(client coreclientv1.CoreV1Interface, eventRecorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+func manageSignerCABundle(client coreclientv1.CoreV1Interface, eventRecorder events.Recorder, forceUpdate bool) (bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(v4_00_assets.MustAsset("v4.0.0/apiservice-cabundle-controller/signing-cabundle.yaml"))
-	existing, err := client.ConfigMaps(configMap.Namespace).Get(configMap.Name, metav1.GetOptions{})
-	if !apierrors.IsNotFound(err) {
-		return existing, false, err
+	if !forceUpdate {
+		// We don't need to force an update; return if the configmap already exists (or error getting).
+		_, err := client.ConfigMaps(configMap.Namespace).Get(configMap.Name, metav1.GetOptions{})
+		if !apierrors.IsNotFound(err) {
+			return false, err
+		}
 	}
 
+	glog.V(4).Infof("updating CA bundle configmap")
 	secret := resourceread.ReadSecretV1OrDie(v4_00_assets.MustAsset("v4.0.0/service-serving-cert-signer-controller/signing-secret.yaml"))
 	currentSigningKeySecret, err := client.Secrets(secret.Namespace).Get(secret.Name, metav1.GetOptions{})
+	// Return err or if the signing secret has no data (should not normally happen).
 	if err != nil || len(currentSigningKeySecret.Data["tls.crt"]) == 0 {
-		return existing, false, err
+		return false, err
 	}
 
 	configMap.Data["ca-bundle.crt"] = string(currentSigningKeySecret.Data["tls.crt"])
 
-	return resourceapply.ApplyConfigMap(client, eventRecorder, configMap)
+	_, mod, err := resourceapply.ApplyConfigMap(client, eventRecorder, configMap)
+	return mod, err
 }
 
-func manageSignerControllerConfig(client coreclientv1.ConfigMapsGetter, eventRecorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+func manageSignerControllerConfig(client coreclientv1.ConfigMapsGetter, eventRecorder events.Recorder) (bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(v4_00_assets.MustAsset("v4.0.0/service-serving-cert-signer-controller/cm.yaml"))
 	defaultConfig := v4_00_assets.MustAsset("v4.0.0/service-serving-cert-signer-controller/defaultconfig.yaml")
 	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "controller-config.yaml", nil, defaultConfig)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
-	return resourceapply.ApplyConfigMap(client, eventRecorder, requiredConfigMap)
+	_, mod, err := resourceapply.ApplyConfigMap(client, eventRecorder, requiredConfigMap)
+	return mod, err
 }
 
-func manageAPIServiceControllerConfig(client coreclientv1.ConfigMapsGetter, eventRecorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+func manageAPIServiceControllerConfig(client coreclientv1.ConfigMapsGetter, eventRecorder events.Recorder) (bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(v4_00_assets.MustAsset("v4.0.0/apiservice-cabundle-controller/cm.yaml"))
 	defaultConfig := v4_00_assets.MustAsset("v4.0.0/apiservice-cabundle-controller/defaultconfig.yaml")
 	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "controller-config.yaml", nil, defaultConfig)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
-	return resourceapply.ApplyConfigMap(client, eventRecorder, requiredConfigMap)
+	_, mod, err := resourceapply.ApplyConfigMap(client, eventRecorder, requiredConfigMap)
+	return mod, err
 }
 
-func manageConfigMapCABundleControllerConfig(client coreclientv1.ConfigMapsGetter, eventRecorder events.Recorder) (*corev1.ConfigMap, bool, error) {
+func manageConfigMapCABundleControllerConfig(client coreclientv1.ConfigMapsGetter, eventRecorder events.Recorder) (bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(v4_00_assets.MustAsset("v4.0.0/configmap-cabundle-controller/cm.yaml"))
 	defaultConfig := v4_00_assets.MustAsset("v4.0.0/configmap-cabundle-controller/defaultconfig.yaml")
 	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "controller-config.yaml", nil, defaultConfig)
 	if err != nil {
-		return nil, false, err
+		return false, err
 	}
-	return resourceapply.ApplyConfigMap(client, eventRecorder, requiredConfigMap)
+	_, mod, err := resourceapply.ApplyConfigMap(client, eventRecorder, requiredConfigMap)
+	return mod, err
 }
 
-func manageSignerControllerDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, forceDeployment bool) (*appsv1.Deployment, bool, error) {
+func manageSignerControllerDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, forceDeployment bool) (bool, error) {
 	return manageDeployment(client, eventRecorder, options, "v4.0.0/service-serving-cert-signer-controller/", forceDeployment)
 }
 
-func manageAPIServiceControllerDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, forceDeployment bool) (*appsv1.Deployment, bool, error) {
+func manageAPIServiceControllerDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, forceDeployment bool) (bool, error) {
 	return manageDeployment(client, eventRecorder, options, "v4.0.0/apiservice-cabundle-controller/", forceDeployment)
 }
 
-func manageConfigMapCABundleControllerDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, forceDeployment bool) (*appsv1.Deployment, bool, error) {
+func manageConfigMapCABundleControllerDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, forceDeployment bool) (bool, error) {
 	return manageDeployment(client, eventRecorder, options, "v4.0.0/configmap-cabundle-controller/", forceDeployment)
 }
 
-func manageDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, resourcePath string, forceDeployment bool) (*appsv1.Deployment, bool, error) {
+func manageDeployment(client appsclientv1.AppsV1Interface, eventRecorder events.Recorder, options *operatorv1.ServiceCA, resourcePath string, forceDeployment bool) (bool, error) {
 	required := resourceread.ReadDeploymentV1OrDie(v4_00_assets.MustAsset(resourcePath + "deployment.yaml"))
 	required.Spec.Template.Spec.Containers[0].Image = os.Getenv("CONTROLLER_IMAGE")
 	required.Spec.Template.Spec.Containers[0].Args = append(required.Spec.Template.Spec.Containers[0].Args, fmt.Sprintf("-v=%s", options.Spec.LogLevel))
+	deployment, mod, err := resourceapply.ApplyDeployment(client, eventRecorder, required, resourcemerge.ExpectedDeploymentGeneration(required, options.Status.Generations), forceDeployment)
+	if err != nil {
+		return mod, err
+	}
+	glog.V(4).Infof("current deployment of %s: %#v", resourcePath, deployment)
+	resourcemerge.SetDeploymentGeneration(&options.Status.Generations, deployment)
 
-	return resourceapply.ApplyDeployment(client, eventRecorder, required, getGeneration(client, operatorclient.TargetNamespace, required.Name), forceDeployment)
+	return mod, nil
 }
 
 func serviceServingCertSignerName() string {

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -43,7 +43,6 @@ import (
 	"strings"
 	"time"
 )
-
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -166,6 +165,10 @@ authentication:
   disabled: true
 authorization:
   disabled: true
+leaderElection:
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
 `)
 
 func v400ApiserviceCabundleControllerDefaultconfigYamlBytes() ([]byte, error) {
@@ -491,6 +494,10 @@ authentication:
   disabled: true
 authorization:
   disabled: true
+leaderElection:
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
 `)
 
 func v400ConfigmapCabundleControllerDefaultconfigYamlBytes() ([]byte, error) {
@@ -854,6 +861,10 @@ authentication:
   disabled: true
 authorization:
   disabled: true
+leaderElection:
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
 `)
 
 func v400ServiceServingCertSignerControllerDefaultconfigYamlBytes() ([]byte, error) {
@@ -1143,37 +1154,37 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"v4.0.0/apiservice-cabundle-controller/clusterrole.yaml":                v400ApiserviceCabundleControllerClusterroleYaml,
-	"v4.0.0/apiservice-cabundle-controller/clusterrolebinding.yaml":         v400ApiserviceCabundleControllerClusterrolebindingYaml,
-	"v4.0.0/apiservice-cabundle-controller/cm.yaml":                         v400ApiserviceCabundleControllerCmYaml,
-	"v4.0.0/apiservice-cabundle-controller/defaultconfig.yaml":              v400ApiserviceCabundleControllerDefaultconfigYaml,
-	"v4.0.0/apiservice-cabundle-controller/deployment.yaml":                 v400ApiserviceCabundleControllerDeploymentYaml,
-	"v4.0.0/apiservice-cabundle-controller/ns.yaml":                         v400ApiserviceCabundleControllerNsYaml,
-	"v4.0.0/apiservice-cabundle-controller/role.yaml":                       v400ApiserviceCabundleControllerRoleYaml,
-	"v4.0.0/apiservice-cabundle-controller/rolebinding.yaml":                v400ApiserviceCabundleControllerRolebindingYaml,
-	"v4.0.0/apiservice-cabundle-controller/sa.yaml":                         v400ApiserviceCabundleControllerSaYaml,
-	"v4.0.0/apiservice-cabundle-controller/signing-cabundle.yaml":           v400ApiserviceCabundleControllerSigningCabundleYaml,
-	"v4.0.0/configmap-cabundle-controller/clusterrole.yaml":                 v400ConfigmapCabundleControllerClusterroleYaml,
-	"v4.0.0/configmap-cabundle-controller/clusterrolebinding.yaml":          v400ConfigmapCabundleControllerClusterrolebindingYaml,
-	"v4.0.0/configmap-cabundle-controller/cm.yaml":                          v400ConfigmapCabundleControllerCmYaml,
-	"v4.0.0/configmap-cabundle-controller/defaultconfig.yaml":               v400ConfigmapCabundleControllerDefaultconfigYaml,
-	"v4.0.0/configmap-cabundle-controller/deployment.yaml":                  v400ConfigmapCabundleControllerDeploymentYaml,
-	"v4.0.0/configmap-cabundle-controller/ns.yaml":                          v400ConfigmapCabundleControllerNsYaml,
-	"v4.0.0/configmap-cabundle-controller/role.yaml":                        v400ConfigmapCabundleControllerRoleYaml,
-	"v4.0.0/configmap-cabundle-controller/rolebinding.yaml":                 v400ConfigmapCabundleControllerRolebindingYaml,
-	"v4.0.0/configmap-cabundle-controller/sa.yaml":                          v400ConfigmapCabundleControllerSaYaml,
-	"v4.0.0/configmap-cabundle-controller/signing-cabundle.yaml":            v400ConfigmapCabundleControllerSigningCabundleYaml,
-	"v4.0.0/service-ca-operator/operator-config.yaml":                       v400ServiceCaOperatorOperatorConfigYaml,
-	"v4.0.0/service-serving-cert-signer-controller/clusterrole.yaml":        v400ServiceServingCertSignerControllerClusterroleYaml,
+	"v4.0.0/apiservice-cabundle-controller/clusterrole.yaml": v400ApiserviceCabundleControllerClusterroleYaml,
+	"v4.0.0/apiservice-cabundle-controller/clusterrolebinding.yaml": v400ApiserviceCabundleControllerClusterrolebindingYaml,
+	"v4.0.0/apiservice-cabundle-controller/cm.yaml": v400ApiserviceCabundleControllerCmYaml,
+	"v4.0.0/apiservice-cabundle-controller/defaultconfig.yaml": v400ApiserviceCabundleControllerDefaultconfigYaml,
+	"v4.0.0/apiservice-cabundle-controller/deployment.yaml": v400ApiserviceCabundleControllerDeploymentYaml,
+	"v4.0.0/apiservice-cabundle-controller/ns.yaml": v400ApiserviceCabundleControllerNsYaml,
+	"v4.0.0/apiservice-cabundle-controller/role.yaml": v400ApiserviceCabundleControllerRoleYaml,
+	"v4.0.0/apiservice-cabundle-controller/rolebinding.yaml": v400ApiserviceCabundleControllerRolebindingYaml,
+	"v4.0.0/apiservice-cabundle-controller/sa.yaml": v400ApiserviceCabundleControllerSaYaml,
+	"v4.0.0/apiservice-cabundle-controller/signing-cabundle.yaml": v400ApiserviceCabundleControllerSigningCabundleYaml,
+	"v4.0.0/configmap-cabundle-controller/clusterrole.yaml": v400ConfigmapCabundleControllerClusterroleYaml,
+	"v4.0.0/configmap-cabundle-controller/clusterrolebinding.yaml": v400ConfigmapCabundleControllerClusterrolebindingYaml,
+	"v4.0.0/configmap-cabundle-controller/cm.yaml": v400ConfigmapCabundleControllerCmYaml,
+	"v4.0.0/configmap-cabundle-controller/defaultconfig.yaml": v400ConfigmapCabundleControllerDefaultconfigYaml,
+	"v4.0.0/configmap-cabundle-controller/deployment.yaml": v400ConfigmapCabundleControllerDeploymentYaml,
+	"v4.0.0/configmap-cabundle-controller/ns.yaml": v400ConfigmapCabundleControllerNsYaml,
+	"v4.0.0/configmap-cabundle-controller/role.yaml": v400ConfigmapCabundleControllerRoleYaml,
+	"v4.0.0/configmap-cabundle-controller/rolebinding.yaml": v400ConfigmapCabundleControllerRolebindingYaml,
+	"v4.0.0/configmap-cabundle-controller/sa.yaml": v400ConfigmapCabundleControllerSaYaml,
+	"v4.0.0/configmap-cabundle-controller/signing-cabundle.yaml": v400ConfigmapCabundleControllerSigningCabundleYaml,
+	"v4.0.0/service-ca-operator/operator-config.yaml": v400ServiceCaOperatorOperatorConfigYaml,
+	"v4.0.0/service-serving-cert-signer-controller/clusterrole.yaml": v400ServiceServingCertSignerControllerClusterroleYaml,
 	"v4.0.0/service-serving-cert-signer-controller/clusterrolebinding.yaml": v400ServiceServingCertSignerControllerClusterrolebindingYaml,
-	"v4.0.0/service-serving-cert-signer-controller/cm.yaml":                 v400ServiceServingCertSignerControllerCmYaml,
-	"v4.0.0/service-serving-cert-signer-controller/defaultconfig.yaml":      v400ServiceServingCertSignerControllerDefaultconfigYaml,
-	"v4.0.0/service-serving-cert-signer-controller/deployment.yaml":         v400ServiceServingCertSignerControllerDeploymentYaml,
-	"v4.0.0/service-serving-cert-signer-controller/ns.yaml":                 v400ServiceServingCertSignerControllerNsYaml,
-	"v4.0.0/service-serving-cert-signer-controller/role.yaml":               v400ServiceServingCertSignerControllerRoleYaml,
-	"v4.0.0/service-serving-cert-signer-controller/rolebinding.yaml":        v400ServiceServingCertSignerControllerRolebindingYaml,
-	"v4.0.0/service-serving-cert-signer-controller/sa.yaml":                 v400ServiceServingCertSignerControllerSaYaml,
-	"v4.0.0/service-serving-cert-signer-controller/signing-secret.yaml":     v400ServiceServingCertSignerControllerSigningSecretYaml,
+	"v4.0.0/service-serving-cert-signer-controller/cm.yaml": v400ServiceServingCertSignerControllerCmYaml,
+	"v4.0.0/service-serving-cert-signer-controller/defaultconfig.yaml": v400ServiceServingCertSignerControllerDefaultconfigYaml,
+	"v4.0.0/service-serving-cert-signer-controller/deployment.yaml": v400ServiceServingCertSignerControllerDeploymentYaml,
+	"v4.0.0/service-serving-cert-signer-controller/ns.yaml": v400ServiceServingCertSignerControllerNsYaml,
+	"v4.0.0/service-serving-cert-signer-controller/role.yaml": v400ServiceServingCertSignerControllerRoleYaml,
+	"v4.0.0/service-serving-cert-signer-controller/rolebinding.yaml": v400ServiceServingCertSignerControllerRolebindingYaml,
+	"v4.0.0/service-serving-cert-signer-controller/sa.yaml": v400ServiceServingCertSignerControllerSaYaml,
+	"v4.0.0/service-serving-cert-signer-controller/signing-secret.yaml": v400ServiceServingCertSignerControllerSigningSecretYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -1215,47 +1226,46 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
-
 var _bintree = &bintree{nil, map[string]*bintree{
 	"v4.0.0": &bintree{nil, map[string]*bintree{
 		"apiservice-cabundle-controller": &bintree{nil, map[string]*bintree{
-			"clusterrole.yaml":        &bintree{v400ApiserviceCabundleControllerClusterroleYaml, map[string]*bintree{}},
+			"clusterrole.yaml": &bintree{v400ApiserviceCabundleControllerClusterroleYaml, map[string]*bintree{}},
 			"clusterrolebinding.yaml": &bintree{v400ApiserviceCabundleControllerClusterrolebindingYaml, map[string]*bintree{}},
-			"cm.yaml":                 &bintree{v400ApiserviceCabundleControllerCmYaml, map[string]*bintree{}},
-			"defaultconfig.yaml":      &bintree{v400ApiserviceCabundleControllerDefaultconfigYaml, map[string]*bintree{}},
-			"deployment.yaml":         &bintree{v400ApiserviceCabundleControllerDeploymentYaml, map[string]*bintree{}},
-			"ns.yaml":                 &bintree{v400ApiserviceCabundleControllerNsYaml, map[string]*bintree{}},
-			"role.yaml":               &bintree{v400ApiserviceCabundleControllerRoleYaml, map[string]*bintree{}},
-			"rolebinding.yaml":        &bintree{v400ApiserviceCabundleControllerRolebindingYaml, map[string]*bintree{}},
-			"sa.yaml":                 &bintree{v400ApiserviceCabundleControllerSaYaml, map[string]*bintree{}},
-			"signing-cabundle.yaml":   &bintree{v400ApiserviceCabundleControllerSigningCabundleYaml, map[string]*bintree{}},
+			"cm.yaml": &bintree{v400ApiserviceCabundleControllerCmYaml, map[string]*bintree{}},
+			"defaultconfig.yaml": &bintree{v400ApiserviceCabundleControllerDefaultconfigYaml, map[string]*bintree{}},
+			"deployment.yaml": &bintree{v400ApiserviceCabundleControllerDeploymentYaml, map[string]*bintree{}},
+			"ns.yaml": &bintree{v400ApiserviceCabundleControllerNsYaml, map[string]*bintree{}},
+			"role.yaml": &bintree{v400ApiserviceCabundleControllerRoleYaml, map[string]*bintree{}},
+			"rolebinding.yaml": &bintree{v400ApiserviceCabundleControllerRolebindingYaml, map[string]*bintree{}},
+			"sa.yaml": &bintree{v400ApiserviceCabundleControllerSaYaml, map[string]*bintree{}},
+			"signing-cabundle.yaml": &bintree{v400ApiserviceCabundleControllerSigningCabundleYaml, map[string]*bintree{}},
 		}},
 		"configmap-cabundle-controller": &bintree{nil, map[string]*bintree{
-			"clusterrole.yaml":        &bintree{v400ConfigmapCabundleControllerClusterroleYaml, map[string]*bintree{}},
+			"clusterrole.yaml": &bintree{v400ConfigmapCabundleControllerClusterroleYaml, map[string]*bintree{}},
 			"clusterrolebinding.yaml": &bintree{v400ConfigmapCabundleControllerClusterrolebindingYaml, map[string]*bintree{}},
-			"cm.yaml":                 &bintree{v400ConfigmapCabundleControllerCmYaml, map[string]*bintree{}},
-			"defaultconfig.yaml":      &bintree{v400ConfigmapCabundleControllerDefaultconfigYaml, map[string]*bintree{}},
-			"deployment.yaml":         &bintree{v400ConfigmapCabundleControllerDeploymentYaml, map[string]*bintree{}},
-			"ns.yaml":                 &bintree{v400ConfigmapCabundleControllerNsYaml, map[string]*bintree{}},
-			"role.yaml":               &bintree{v400ConfigmapCabundleControllerRoleYaml, map[string]*bintree{}},
-			"rolebinding.yaml":        &bintree{v400ConfigmapCabundleControllerRolebindingYaml, map[string]*bintree{}},
-			"sa.yaml":                 &bintree{v400ConfigmapCabundleControllerSaYaml, map[string]*bintree{}},
-			"signing-cabundle.yaml":   &bintree{v400ConfigmapCabundleControllerSigningCabundleYaml, map[string]*bintree{}},
+			"cm.yaml": &bintree{v400ConfigmapCabundleControllerCmYaml, map[string]*bintree{}},
+			"defaultconfig.yaml": &bintree{v400ConfigmapCabundleControllerDefaultconfigYaml, map[string]*bintree{}},
+			"deployment.yaml": &bintree{v400ConfigmapCabundleControllerDeploymentYaml, map[string]*bintree{}},
+			"ns.yaml": &bintree{v400ConfigmapCabundleControllerNsYaml, map[string]*bintree{}},
+			"role.yaml": &bintree{v400ConfigmapCabundleControllerRoleYaml, map[string]*bintree{}},
+			"rolebinding.yaml": &bintree{v400ConfigmapCabundleControllerRolebindingYaml, map[string]*bintree{}},
+			"sa.yaml": &bintree{v400ConfigmapCabundleControllerSaYaml, map[string]*bintree{}},
+			"signing-cabundle.yaml": &bintree{v400ConfigmapCabundleControllerSigningCabundleYaml, map[string]*bintree{}},
 		}},
 		"service-ca-operator": &bintree{nil, map[string]*bintree{
 			"operator-config.yaml": &bintree{v400ServiceCaOperatorOperatorConfigYaml, map[string]*bintree{}},
 		}},
 		"service-serving-cert-signer-controller": &bintree{nil, map[string]*bintree{
-			"clusterrole.yaml":        &bintree{v400ServiceServingCertSignerControllerClusterroleYaml, map[string]*bintree{}},
+			"clusterrole.yaml": &bintree{v400ServiceServingCertSignerControllerClusterroleYaml, map[string]*bintree{}},
 			"clusterrolebinding.yaml": &bintree{v400ServiceServingCertSignerControllerClusterrolebindingYaml, map[string]*bintree{}},
-			"cm.yaml":                 &bintree{v400ServiceServingCertSignerControllerCmYaml, map[string]*bintree{}},
-			"defaultconfig.yaml":      &bintree{v400ServiceServingCertSignerControllerDefaultconfigYaml, map[string]*bintree{}},
-			"deployment.yaml":         &bintree{v400ServiceServingCertSignerControllerDeploymentYaml, map[string]*bintree{}},
-			"ns.yaml":                 &bintree{v400ServiceServingCertSignerControllerNsYaml, map[string]*bintree{}},
-			"role.yaml":               &bintree{v400ServiceServingCertSignerControllerRoleYaml, map[string]*bintree{}},
-			"rolebinding.yaml":        &bintree{v400ServiceServingCertSignerControllerRolebindingYaml, map[string]*bintree{}},
-			"sa.yaml":                 &bintree{v400ServiceServingCertSignerControllerSaYaml, map[string]*bintree{}},
-			"signing-secret.yaml":     &bintree{v400ServiceServingCertSignerControllerSigningSecretYaml, map[string]*bintree{}},
+			"cm.yaml": &bintree{v400ServiceServingCertSignerControllerCmYaml, map[string]*bintree{}},
+			"defaultconfig.yaml": &bintree{v400ServiceServingCertSignerControllerDefaultconfigYaml, map[string]*bintree{}},
+			"deployment.yaml": &bintree{v400ServiceServingCertSignerControllerDeploymentYaml, map[string]*bintree{}},
+			"ns.yaml": &bintree{v400ServiceServingCertSignerControllerNsYaml, map[string]*bintree{}},
+			"role.yaml": &bintree{v400ServiceServingCertSignerControllerRoleYaml, map[string]*bintree{}},
+			"rolebinding.yaml": &bintree{v400ServiceServingCertSignerControllerRolebindingYaml, map[string]*bintree{}},
+			"sa.yaml": &bintree{v400ServiceServingCertSignerControllerSaYaml, map[string]*bintree{}},
+			"signing-secret.yaml": &bintree{v400ServiceServingCertSignerControllerSigningSecretYaml, map[string]*bintree{}},
 		}},
 	}},
 }}
@@ -1306,3 +1316,4 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
+


### PR DESCRIPTION
This PR contains a few changes that lets all secrets and configmaps (and API service bundles) be updated when you run `oc delete secret/service-serving-cert-signer-signing-key -n openshift-service-ca `
- Always trigger new deployments of the 3 controllers whenever a controller resource is changed. 
- Fix replacement of the CA bundle when the signing key changes. 
- Allow regeneration of a cert in an existing secret, and refactor the secret update error reporting.
@openshift/sig-auth 