### PR TITLE
Bug 1664421: remove emoji from event logs

### DIFF
--- a/pkg/boilerplate/operator/option.go
+++ b/pkg/boilerplate/operator/option.go
@@ -6,10 +6,6 @@ import (
 	"github.com/openshift/service-ca-operator/pkg/boilerplate/controller"
 )
 
-// key is the singleton key shared by all events
-// the value is irrelevant, but pandas are awesome
-const key = "🐼"
-
 type Option func(*operator)
 
 func WithInformer(getter controller.InformerGetter, filter controller.Filter) Option {
@@ -17,7 +13,7 @@ func WithInformer(getter controller.InformerGetter, filter controller.Filter) Op
 		o.opts = append(o.opts,
 			controller.WithInformer(getter, controller.FilterFuncs{
 				ParentFunc: func(obj v1.Object) (namespace, name string) {
-					return key, key // return our singleton key for all events
+					return o.name, o.name // return our singleton key for all events
 				},
 				AddFunc:    filter.Add,
 				UpdateFunc: filter.Update,


### PR DESCRIPTION
Cause: operator used an emoji as the operator informer key

Consequence: error logs contain emoji character, confusing users

Fix: change key to more boring but informative value

Result: errors from operator controller shows "service-ca-operator"
instead of emoji