### PR TITLE
Use CVO for operator config

### DIFF
--- a/manifests/0000_09_service-ca-operator_03_operator.cr.yaml
+++ b/manifests/0000_09_service-ca-operator_03_operator.cr.yaml
@@ -2,5 +2,7 @@ apiVersion: operator.openshift.io/v1
 kind: ServiceCA
 metadata:
   name: cluster
+  annotations:
+    release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 
@@ -22,7 +21,6 @@ import (
 
 	"github.com/openshift/service-ca-operator/pkg/controller/api"
 	"github.com/openshift/service-ca-operator/pkg/operator/operatorclient"
-	"github.com/openshift/service-ca-operator/pkg/operator/v4_00_assets"
 )
 
 const (
@@ -48,10 +46,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	if err != nil {
 		return err
 	}
-	dynamicClient, err := dynamic.NewForConfig(ctx.KubeConfig)
-	if err != nil {
-		return err
-	}
 	configClient, err := configv1client.NewForConfig(ctx.KubeConfig)
 	if err != nil {
 		return err
@@ -67,10 +61,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		operatorclient.OperatorNamespace,
 		operatorclient.TargetNamespace,
 	)
-	v1helpers.EnsureOperatorConfigExists(
-		dynamicClient,
-		v4_00_assets.MustAsset("v4.0.0/service-ca-operator/operator-config.yaml"),
-		operatorv1.GroupVersion.WithResource("servicecas"))
 
 	operatorClient := &operatorclient.OperatorClient{
 		Informers: operatorConfigInformers,

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -20,7 +20,6 @@
 // bindata/v4.0.0/configmap-cabundle-controller/rolebinding.yaml
 // bindata/v4.0.0/configmap-cabundle-controller/sa.yaml
 // bindata/v4.0.0/configmap-cabundle-controller/signing-cabundle.yaml
-// bindata/v4.0.0/service-ca-operator/operator-config.yaml
 // bindata/v4.0.0/service-serving-cert-signer-controller/clusterrole.yaml
 // bindata/v4.0.0/service-serving-cert-signer-controller/clusterrolebinding.yaml
 // bindata/v4.0.0/service-serving-cert-signer-controller/cm.yaml
@@ -734,29 +733,6 @@ func v400ConfigmapCabundleControllerSigningCabundleYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v400ServiceCaOperatorOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
-kind: ServiceCA
-metadata:
-  name: cluster
-spec:
-  managementState: Managed
-`)
-
-func v400ServiceCaOperatorOperatorConfigYamlBytes() ([]byte, error) {
-	return _v400ServiceCaOperatorOperatorConfigYaml, nil
-}
-
-func v400ServiceCaOperatorOperatorConfigYaml() (*asset, error) {
-	bytes, err := v400ServiceCaOperatorOperatorConfigYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v4.0.0/service-ca-operator/operator-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 var _v400ServiceServingCertSignerControllerClusterroleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -1174,7 +1150,6 @@ var _bindata = map[string]func() (*asset, error){
 	"v4.0.0/configmap-cabundle-controller/rolebinding.yaml": v400ConfigmapCabundleControllerRolebindingYaml,
 	"v4.0.0/configmap-cabundle-controller/sa.yaml": v400ConfigmapCabundleControllerSaYaml,
 	"v4.0.0/configmap-cabundle-controller/signing-cabundle.yaml": v400ConfigmapCabundleControllerSigningCabundleYaml,
-	"v4.0.0/service-ca-operator/operator-config.yaml": v400ServiceCaOperatorOperatorConfigYaml,
 	"v4.0.0/service-serving-cert-signer-controller/clusterrole.yaml": v400ServiceServingCertSignerControllerClusterroleYaml,
 	"v4.0.0/service-serving-cert-signer-controller/clusterrolebinding.yaml": v400ServiceServingCertSignerControllerClusterrolebindingYaml,
 	"v4.0.0/service-serving-cert-signer-controller/cm.yaml": v400ServiceServingCertSignerControllerCmYaml,
@@ -1251,9 +1226,6 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"rolebinding.yaml": &bintree{v400ConfigmapCabundleControllerRolebindingYaml, map[string]*bintree{}},
 			"sa.yaml": &bintree{v400ConfigmapCabundleControllerSaYaml, map[string]*bintree{}},
 			"signing-cabundle.yaml": &bintree{v400ConfigmapCabundleControllerSigningCabundleYaml, map[string]*bintree{}},
-		}},
-		"service-ca-operator": &bintree{nil, map[string]*bintree{
-			"operator-config.yaml": &bintree{v400ServiceCaOperatorOperatorConfigYaml, map[string]*bintree{}},
 		}},
 		"service-serving-cert-signer-controller": &bintree{nil, map[string]*bintree{
 			"clusterrole.yaml": &bintree{v400ServiceServingCertSignerControllerClusterroleYaml, map[string]*bintree{}},


### PR DESCRIPTION
Use the CVO to manage the operator config, instead of deprecated config helper