### PR TITLE
Shorten signing key secret name

### DIFF
--- a/bindata/v4.0.0/service-serving-cert-signer-controller/deployment.yaml
+++ b/bindata/v4.0.0/service-serving-cert-signer-controller/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       volumes:
       - name: signing-key
         secret:
-          secretName: service-serving-cert-signer-signing-key
+          secretName: signing-key
       - name: config
         configMap:
           name: service-serving-cert-signer-config

--- a/bindata/v4.0.0/service-serving-cert-signer-controller/signing-secret.yaml
+++ b/bindata/v4.0.0/service-serving-cert-signer-controller/signing-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: openshift-service-ca
-  name: service-serving-cert-signer-signing-key
+  name: signing-key
 type: kubernetes.io/tls
 data:
   tls.crt:

--- a/pkg/controller/api/resourcenames.go
+++ b/pkg/controller/api/resourcenames.go
@@ -25,5 +25,5 @@ const (
 	ConfigMapInjectorDeploymentName  = "configmap-cabundle-injector"
 
 	// Secrets
-	SignerControllerSecretName = "service-serving-cert-signer-signing-key"
+	SignerControllerSecretName = "signing-key"
 )

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -898,7 +898,7 @@ spec:
       volumes:
       - name: signing-key
         secret:
-          secretName: service-serving-cert-signer-signing-key
+          secretName: signing-key
       - name: config
         configMap:
           name: service-serving-cert-signer-config
@@ -1056,7 +1056,7 @@ var _v400ServiceServingCertSignerControllerSigningSecretYaml = []byte(`apiVersio
 kind: Secret
 metadata:
   namespace: openshift-service-ca
-  name: service-serving-cert-signer-signing-key
+  name: signing-key
 type: kubernetes.io/tls
 data:
   tls.crt:

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -29,7 +29,7 @@ const (
 	apiInjectorPodPrefix         = api.APIServiceInjectorDeploymentName
 	configMapInjectorPodPrefix   = api.ConfigMapInjectorDeploymentName
 	caControllerPodPrefix        = api.SignerControllerDeploymentName
-	signingKeySecretName         = "service-serving-cert-signer-signing-key"
+	signingKeySecretName         = api.SignerControllerSecretName
 )
 
 func hasPodWithPrefixName(client *kubernetes.Clientset, name, namespace string) bool {


### PR DESCRIPTION
@openshift/sig-auth 
Shortening this name will be useful because we have one step in the documentation that will reference the secret (force rotate service CA), making it effectively an API.