### PR TITLE
Add node-selector annotation to namespace

### DIFF
--- a/bindata/v4.0.0/apiservice-cabundle-controller/ns.yaml
+++ b/bindata/v4.0.0/apiservice-cabundle-controller/ns.yaml
@@ -4,3 +4,5 @@ metadata:
   name: openshift-service-ca
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/bindata/v4.0.0/configmap-cabundle-controller/ns.yaml
+++ b/bindata/v4.0.0/configmap-cabundle-controller/ns.yaml
@@ -4,3 +4,5 @@ metadata:
   name: openshift-service-ca
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/bindata/v4.0.0/service-serving-cert-signer-controller/ns.yaml
+++ b/bindata/v4.0.0/service-serving-cert-signer-controller/ns.yaml
@@ -4,3 +4,5 @@ metadata:
   name: openshift-service-ca
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""

--- a/manifests/0000_09_service-ca-operator_01_namespace.yaml
+++ b/manifests/0000_09_service-ca-operator_01_namespace.yaml
@@ -4,3 +4,5 @@ metadata:
   labels:
     openshift.io/run-level: "1"
   name: openshift-service-ca-operator
+  annotations:
+    openshift.io/node-selector: ""

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -255,7 +255,10 @@ kind: Namespace
 metadata:
   name: openshift-service-ca
   labels:
-    openshift.io/run-level: "1"`)
+    openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""
+`)
 
 func v400ApiserviceCabundleControllerNsYamlBytes() ([]byte, error) {
 	return _v400ApiserviceCabundleControllerNsYaml, nil
@@ -585,6 +588,8 @@ metadata:
   name: openshift-service-ca
   labels:
     openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""
 `)
 
 func v400ConfigmapCabundleControllerNsYamlBytes() ([]byte, error) {
@@ -928,7 +933,10 @@ kind: Namespace
 metadata:
   name: openshift-service-ca
   labels:
-    openshift.io/run-level: "1"`)
+    openshift.io/run-level: "1"
+  annotations:
+    openshift.io/node-selector: ""
+`)
 
 func v400ServiceServingCertSignerControllerNsYamlBytes() ([]byte, error) {
 	return _v400ServiceServingCertSignerControllerNsYaml, nil


### PR DESCRIPTION
**Why this change?**
When https://github.com/openshift/cluster-kube-apiserver-operator/pull/394 merges, all the pods running openshift cluster will have a [defaultNodeSelector](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#setting-the-cluster-wide-default-node-selector) if it has been set by cluster-admin including pods running in `openshift-*` namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

**What should I do?**
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR. If not feel free to close this. The annotation added as part of this PR lets all the pods created within your project to not have the defaultNodeSelector set.


/cc @deads2k @sjenning 
