### PR TITLE
Enable Auth for metrics endpoint

### DIFF
--- a/manifests/03_cm.yaml
+++ b/manifests/03_cm.yaml
@@ -7,7 +7,3 @@ data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1
     kind: GenericOperatorConfig
-    authentication:
-      disabled: true
-    authorization:
-      disabled: true


### PR DESCRIPTION
Enable Auth for metrics endpoint in [service-ca-operator](https://github.com/openshift/service-ca-operator).
By default delegated authentication and authorization are enabled.
Currently the configmap explicitly disables delegated authentication and authorization.
Remove the override to enable delegated authentication and authorization.

See https://github.com/openshift/cluster-authentication-operator/pull/123 which solves the same problem for [openshift/cluster-authentication-operator](https://github.com/openshift/cluster-authentication-operator).