### PR TITLE
bug 1711075: set resource requests on containers

### DIFF
--- a/bindata/v4.0.0/apiservice-cabundle-controller/deployment.yaml
+++ b/bindata/v4.0.0/apiservice-cabundle-controller/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         ports:
         - containerPort: 8443
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/bindata/v4.0.0/configmap-cabundle-controller/deployment.yaml
+++ b/bindata/v4.0.0/configmap-cabundle-controller/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         ports:
         - containerPort: 8443
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/bindata/v4.0.0/service-serving-cert-signer-controller/deployment.yaml
+++ b/bindata/v4.0.0/service-serving-cert-signer-controller/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         ports:
         - containerPort: 8443
+        resources:
+          requests:
+            memory: 120Mi
+            cpu: 10m
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -25,6 +25,10 @@ spec:
         args:
         - "--config=/var/run/configmaps/config/operator-config.yaml"
         - "-v=4"
+        resources:
+          requests:
+            memory: 80Mi
+            cpu: 10m
         env:
         - name: CONTROLLER_IMAGE
           value: quay.io/openshift/origin-service-ca-operator:v4.0

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -213,6 +213,10 @@ spec:
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         ports:
         - containerPort: 8443
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
@@ -551,6 +555,10 @@ spec:
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         ports:
         - containerPort: 8443
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
@@ -903,6 +911,10 @@ spec:
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         ports:
         - containerPort: 8443
+        resources:
+          requests:
+            memory: 120Mi
+            cpu: 10m
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config


### PR DESCRIPTION
Prevent pods from eviction, OOMKilling, and CPU starvation when
running in the BestEffort QoS by setting resource requests.

https://github.com/openshift/origin/pull/22787

Limits used:

Memory:
service-ca-operator 80Mi
apiservice-cabundle-injector 50Mi
configmap-cabundle-injector 50Mi
service-serving-cert-signer 120Mi

CPU:
all 10m

bz: https://bugzilla.redhat.com/show_bug.cgi?id=1711075