### PR TITLE
 chore(Dockerfile(.rhel7)*): update maintainer team ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENTRYPOINT ["/usr/bin/service-ca-operator"]
 LABEL io.k8s.display-name="OpenShift service-ca-operator" \
       io.k8s.description="This is a component of OpenShift and manages serving certificates" \
       com.redhat.component="service-ca-operator" \
-      maintainer="OpenShift Auth Team <aos-auth-team@redhat.com>" \
+      maintainer="OpenShift API/Auth/Scheduling Team <aos-master@redhat.com>" \
       name="openshift/ose-service-ca-operator" \
       version="v4.0.0" \
       io.openshift.tags="openshift" \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,7 +10,7 @@ ENTRYPOINT ["/usr/bin/service-ca-operator"]
 LABEL io.k8s.display-name="OpenShift service-ca-operator" \
       io.k8s.description="This is a component of OpenShift and manages serving certificates" \
       com.redhat.component="service-ca-operator" \
-      maintainer="OpenShift Auth Team <aos-auth-team@redhat.com>" \
+      maintainer="OpenShift API/Auth/Scheduling Team <aos-master@redhat.com>" \
       name="openshift/ose-service-ca-operator" \
       version="v4.0.0" \
       io.openshift.tags="openshift" \


### PR DESCRIPTION
Update maintainer label in dockerfiles from Auth Team to
new API/Auth/Scheduling Team to reflect team changes from
group-b re-org.

Let me know if you plan to change the mailing list for the api/auth/scheduling team @sttts from aos-master to something else and I'll update this pr.

cc @mfojtik