### PR TITLE
status: do not flap degraded from false to unknown

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -100,9 +100,7 @@ func (c serviceCAOperator) Sync(obj metav1.Object) error {
 		if err != nil {
 			setDegradedTrue(operatorConfigCopy, "OperatorSyncLoopError", err.Error())
 		} else {
-			if v1helpers.IsOperatorConditionTrue(operatorConfigCopy.Status.Conditions, operatorv1.OperatorStatusTypeDegraded) {
-				setDegradedFalse(operatorConfigCopy, "OperatorSyncLoopComplete")
-			}
+			setDegradedFalse(operatorConfigCopy, "OperatorSyncLoopComplete")
 			existingDeployments, err := c.appsv1Client.Deployments(operatorclient.TargetNamespace).List(metav1.ListOptions{})
 			if err != nil {
 				return fmt.Errorf("Error listing deployments in %s: %v", operatorclient.TargetNamespace, err)


### PR DESCRIPTION
In case the Degraded condition is not set to False, the union will set it as Degraded=Unknown with NoData as reason (because we haven't said whether we are or not degraded).

This will always set degraded to false when there is no error returned from the loop.