### PR TITLE
Enable injection of service CA bundle for admission webhooks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ metadata:
 ```
 
 * **generic cabundle injector:**
-  * Watches for apiservices and crds annotated with 'service.beta.openshift.io/inject-cabundle=true' and sets the appropriate ca bundle field (apiservice -> spec.caBundle, spec.conversion.webhook.clientConfig.caBundle) with a base64url-encoded CA signing bundle. The following example is for apiservices:
+  * Watches for apiservices, mutatingwebhookconfig, validatingwebhookconfig and crds annotated with 'service.beta.openshift.io/inject-cabundle=true' and sets the appropriate ca bundle field (apiservice -> spec.caBundle, *webhookconfig -> webhooks[].clientConfig.caBundle, spec.conversion.webhook.clientConfig.caBundle) with a base64url-encoded CA signing bundle. The following example is for apiservices:
 
 ```
 $ oc get apiservice/v1.build.openshift.io -o yaml

--- a/bindata/v4.0.0/controller/clusterrole.yaml
+++ b/bindata/v4.0.0/controller/clusterrole.yaml
@@ -25,6 +25,16 @@ rules:
   - update
   - patch
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/pkg/controller/cabundleinjector/mutatingwebhook.go
+++ b/pkg/controller/cabundleinjector/mutatingwebhook.go
@@ -1,0 +1,59 @@
+package cabundleinjector
+
+import (
+	"bytes"
+
+	admissionreg "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionregclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	admissionreglister "k8s.io/client-go/listers/admissionregistration/v1"
+	"k8s.io/klog"
+)
+
+type mutatingWebhookCABundleInjector struct {
+	client   admissionregclient.MutatingWebhookConfigurationInterface
+	lister   admissionreglister.MutatingWebhookConfigurationLister
+	caBundle []byte
+}
+
+func newMutatingWebhookInjectorConfig(config *caBundleInjectorConfig) controllerConfig {
+	informer := config.kubeInformers.Admissionregistration().V1().MutatingWebhookConfigurations()
+	keySyncer := &mutatingWebhookCABundleInjector{
+		client:   config.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations(),
+		lister:   informer.Lister(),
+		caBundle: config.caBundle,
+	}
+	return controllerConfig{
+		name:           "MutatingWebhookCABundleInjector",
+		keySyncer:      keySyncer,
+		informerGetter: informer,
+	}
+}
+
+func (bi *mutatingWebhookCABundleInjector) Key(namespace, name string) (metav1.Object, error) {
+	return bi.lister.Get(name)
+}
+
+func (bi *mutatingWebhookCABundleInjector) Sync(obj metav1.Object) error {
+	webhookConfig := obj.(*admissionreg.MutatingWebhookConfiguration)
+
+	webhooksNeedingUpdate := []int{}
+	for i, webhook := range webhookConfig.Webhooks {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, bi.caBundle) {
+			webhooksNeedingUpdate = append(webhooksNeedingUpdate, i)
+		}
+	}
+	if len(webhooksNeedingUpdate) == 0 {
+		return nil
+	}
+
+	klog.Infof("updating mutatingwebhookconfiguration %s with the service signing CA bundle", webhookConfig.Name)
+
+	// make a copy to avoid mutating cache state
+	webhookConfigCopy := webhookConfig.DeepCopy()
+	for i := range webhooksNeedingUpdate {
+		webhookConfigCopy.Webhooks[i].ClientConfig.CABundle = bi.caBundle
+	}
+	_, err := bi.client.Update(webhookConfigCopy)
+	return err
+}

--- a/pkg/controller/cabundleinjector/starter.go
+++ b/pkg/controller/cabundleinjector/starter.go
@@ -61,6 +61,8 @@ func StartCABundleInjector(ctx context.Context, controllerContext *controllercmd
 		newAPIServiceInjectorConfig,
 		newConfigMapInjectorConfig,
 		newCRDInjectorConfig,
+		newMutatingWebhookInjectorConfig,
+		newValidatingWebhookInjectorConfig,
 	}
 	controllerRunners := []controller.Runner{}
 	for _, configConstructor := range configConstructors {

--- a/pkg/controller/cabundleinjector/validatingwebhook.go
+++ b/pkg/controller/cabundleinjector/validatingwebhook.go
@@ -1,0 +1,59 @@
+package cabundleinjector
+
+import (
+	"bytes"
+
+	admissionreg "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	admissionregclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	admissionreglister "k8s.io/client-go/listers/admissionregistration/v1"
+	"k8s.io/klog"
+)
+
+type validatingWebhookCABundleInjector struct {
+	client   admissionregclient.ValidatingWebhookConfigurationInterface
+	lister   admissionreglister.ValidatingWebhookConfigurationLister
+	caBundle []byte
+}
+
+func newValidatingWebhookInjectorConfig(config *caBundleInjectorConfig) controllerConfig {
+	informer := config.kubeInformers.Admissionregistration().V1().ValidatingWebhookConfigurations()
+	keySyncer := &validatingWebhookCABundleInjector{
+		client:   config.kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations(),
+		lister:   informer.Lister(),
+		caBundle: config.caBundle,
+	}
+	return controllerConfig{
+		name:           "ValidatingWebhookCABundleInjector",
+		keySyncer:      keySyncer,
+		informerGetter: informer,
+	}
+}
+
+func (bi *validatingWebhookCABundleInjector) Key(namespace, name string) (metav1.Object, error) {
+	return bi.lister.Get(name)
+}
+
+func (bi *validatingWebhookCABundleInjector) Sync(obj metav1.Object) error {
+	webhookConfig := obj.(*admissionreg.ValidatingWebhookConfiguration)
+
+	webhooksNeedingUpdate := []int{}
+	for i, webhook := range webhookConfig.Webhooks {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, bi.caBundle) {
+			webhooksNeedingUpdate = append(webhooksNeedingUpdate, i)
+		}
+	}
+	if len(webhooksNeedingUpdate) == 0 {
+		return nil
+	}
+
+	klog.Infof("updating validatingwebhookconfiguration %s with the service signing CA bundle", webhookConfig.Name)
+
+	// make a copy to avoid mutating cache state
+	webhookConfigCopy := webhookConfig.DeepCopy()
+	for i := range webhooksNeedingUpdate {
+		webhookConfigCopy.Webhooks[i].ClientConfig.CABundle = bi.caBundle
+	}
+	_, err := bi.client.Update(webhookConfigCopy)
+	return err
+}

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -80,6 +80,16 @@ rules:
   - update
   - patch
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions


### PR DESCRIPTION
This PR adds support for injection of service CA bundle for `MutatingWebhookConfiguration` and `ValidatingWebhookConfiguration`, and supersedes #51.


Fixes #63 

Co-authored-by: Daniel Spangenberg <daniel.spangenberg@redhat.com>