### PR TITLE
Revert the removal of the service CA from serving certs

### DIFF
--- a/pkg/controller/api/api.go
+++ b/pkg/controller/api/api.go
@@ -39,6 +39,14 @@ func HasInjectCABundleAnnotationUpdate(old, cur v1.Object) bool {
 
 // Annotations on service
 const (
+	// TODO(marun) When adding a GA serving cert annotation, consider
+	// discontinuing the practice of including the issuing cert with the serving
+	// cert. This behavior was accidental (at some point the issuing CA was an
+	// intermediate rather than the current self-signed root) but had to be
+	// maintained to support legacy clients that ended up reusing the serving cert
+	// as a CA bundle. Clients of a GA annotation should be expected to use a
+	// proper CA bundle.
+
 	// ServingCertSecretAnnotation stores the name of the secret to generate into.
 	ServingCertSecretAnnotation      = "service.beta.openshift.io/serving-cert-secret-name"
 	AlphaServingCertSecretAnnotation = "service.alpha.openshift.io/serving-cert-secret-name"

--- a/pkg/controller/servingcert/controller/secret_creating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller.go
@@ -333,17 +333,14 @@ func MakeServingCert(dnsSuffix string, ca *crypto.CA, intermediateCACert *x509.C
 	if err != nil {
 		return nil, err
 	}
-	if len(servingCert.Certs) > 1 {
-		// Only include the generated cert. The issuing cert will be provided to
-		// clients via the ca bundle.
-		servingCert.Certs = servingCert.Certs[:1]
-	}
+
 	// Including the intermediate cert will ensure that clients with a
 	// stale ca bundle (containing the previous CA but not the current
 	// one) will be able to trust the serving cert.
 	if intermediateCACert != nil {
 		servingCert.Certs = append(servingCert.Certs, intermediateCACert)
 	}
+
 	return servingCert, nil
 }
 


### PR DESCRIPTION
The addition of CA rotation also saw the removal of the signing CA from generated serving certificates. This broke legacy clients that depended on this behavior. To support code-free changes to those legacy clients, this change maintains the old behavior of including the signing CA so long as the alpha annotation is used. Beta and above will not include the signing CA.
