### PR TITLE
Disable automatic CA rotation for now

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -1,0 +1,44 @@
+package operator
+
+import (
+	"encoding/json"
+)
+
+type unsupportedServiceCAConfig struct {
+	TimeBasedRotation timeBasedRotationConfig `json:"timeBasedRotation"`
+
+	ForceRotation forceRotationConfig `json:"forceRotation"`
+}
+
+type timeBasedRotationConfig struct {
+	Enabled bool `json:"enabled"`
+}
+
+type forceRotationConfig struct {
+	Reason string `json:"reason"`
+}
+
+// loadUnsupportedServiceCAConfig loads an unsupportedServiceCAConfig from raw bytes.
+func loadUnsupportedServiceCAConfig(raw []byte) (unsupportedServiceCAConfig, error) {
+	serviceCAConfig := unsupportedServiceCAConfig{}
+	if len(raw) == 0 {
+		return serviceCAConfig, nil
+	}
+	err := json.Unmarshal(raw, &serviceCAConfig)
+	return serviceCAConfig, err
+}
+
+// RawUnsupportedServiceCAConfig returns the raw value of the operator field
+// UnsupportedConfigOverrides for whether time-based rotation is enabled and the
+// given force rotation reason.
+func RawUnsupportedServiceCAConfig(enabled bool, reason string) ([]byte, error) {
+	config := &unsupportedServiceCAConfig{
+		TimeBasedRotation: timeBasedRotationConfig{
+			Enabled: enabled,
+		},
+		ForceRotation: forceRotationConfig{
+			Reason: reason,
+		},
+	}
+	return json.Marshal(config)
+}

--- a/pkg/operator/rotate.go
+++ b/pkg/operator/rotate.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -26,13 +25,6 @@ const (
 	// trusted) should be valid for at least this long.
 	minimumTrustDuration = 182 * 24 * time.Hour
 )
-
-type unsupportedServiceCAConfig struct {
-	ForceRotation forceRotationConfig `json:"forceRotation"`
-}
-type forceRotationConfig struct {
-	Reason string `json:"reason"`
-}
 
 type signingCA struct {
 	config             *crypto.TLSCertificateConfig
@@ -72,14 +64,19 @@ func (ca *signingCA) updateSigningSecret(secret *corev1.Secret) error {
 // current CA is not more than half-way expired or if a forced rotation was not
 // requested, and in this case an empty rotation message will be returned.
 func maybeRotateSigningSecret(secret *corev1.Secret, currentCACert *x509.Certificate, rawUnsupportedServiceCAConfig []byte) (string, error) {
-	reason, err := forceRotationReason(rawUnsupportedServiceCAConfig)
+	serviceCAConfig, err := loadUnsupportedServiceCAConfig(rawUnsupportedServiceCAConfig)
 	if err != nil {
-		return "", fmt.Errorf("failed to read force rotation reason: %v", err)
+		return "", fmt.Errorf("failed to load unsupportedConfigOverrides: %v", err)
 	}
+
+	reason := serviceCAConfig.ForceRotation.Reason
 	forcedRotation := forcedRotationRequired(secret, reason)
 
-	minimumExpiry := time.Now().Add(minimumTrustDuration)
-	timeBasedRotation := currentCACert.NotAfter.Before(minimumExpiry)
+	timeBasedRotation := false
+	if serviceCAConfig.TimeBasedRotation.Enabled {
+		minimumExpiry := time.Now().Add(minimumTrustDuration)
+		timeBasedRotation = currentCACert.NotAfter.Before(minimumExpiry)
+	}
 
 	if !(forcedRotation || timeBasedRotation) {
 		return "", nil
@@ -194,30 +191,6 @@ func createIntermediateCACert(targetCACert, signingCACert *x509.Certificate, sig
 	}
 
 	return caCert, nil
-}
-
-// forceRotationReason attempts to retrieve a force rotation reason
-// from the provided raw UnsupportedConfigOverrides.
-func forceRotationReason(rawUnsupportedServiceCAConfig []byte) (string, error) {
-	serviceCAConfig := &unsupportedServiceCAConfig{}
-	if raw := rawUnsupportedServiceCAConfig; len(raw) > 0 {
-		if err := json.Unmarshal(raw, serviceCAConfig); err != nil {
-			return "", err
-		}
-	}
-
-	return serviceCAConfig.ForceRotation.Reason, nil
-}
-
-// RawUnsupportedServiceCAConfig returns the raw value of the operator field
-// UnsupportedConfigOverrides for the given force rotation reason.
-func RawUnsupportedServiceCAConfig(reason string) ([]byte, error) {
-	config := &unsupportedServiceCAConfig{
-		ForceRotation: forceRotationConfig{
-			Reason: reason,
-		},
-	}
-	return json.Marshal(config)
 }
 
 // forcedRotationRequired indicates whether the force rotation reason is not empty and

--- a/pkg/operator/rotate_test.go
+++ b/pkg/operator/rotate_test.go
@@ -91,9 +91,13 @@ func TestMaybeRotateSigningSecret(t *testing.T) {
 
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
-			rawUnsupportedServiceCAConfig, err := RawUnsupportedServiceCAConfig(tc.reason)
-			if err != nil {
-				t.Fatalf("failed to create raw unsupported config overrides: %v", err)
+			var rawUnsupportedServiceCAConfig []byte
+			if len(tc.reason) > 0 || tc.rotationExpected {
+				var err error
+				rawUnsupportedServiceCAConfig, err = RawUnsupportedServiceCAConfig(true, tc.reason)
+				if err != nil {
+					t.Fatalf("failed to create raw unsupported config overrides: %v", err)
+				}
 			}
 			secret := tc.secret.DeepCopy()
 			rotationMessage, err := maybeRotateSigningSecret(secret, tc.caCert, rawUnsupportedServiceCAConfig)


### PR DESCRIPTION
It can still be enabled via an unsupported config override to allow the codepath to remain tested in e2e. It is intended to be enabled in a future release.