### PR TITLE
Support setting CA validity duration via unsupportedConfigOverrides

### DIFF
--- a/pkg/operator/cert.go
+++ b/pkg/operator/cert.go
@@ -1,0 +1,58 @@
+package operator
+
+import (
+	"crypto/x509"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/service-ca-operator/pkg/operator/util"
+)
+
+// maybeUpdateExpiry updates the expiry of the self-signed CA and returns it if the
+// provided duration is greater than zero. If an error occurs or the duration is
+// zero, the original CA is returned.
+func maybeUpdateExpiry(caConfig *crypto.TLSCertificateConfig, duration time.Duration) (*crypto.TLSCertificateConfig, error) {
+	if duration.Nanoseconds() == 0 {
+		return caConfig, nil
+	}
+	// operator-go's cert generation only accepts an expiry in days. To
+	// ensure support for all validity durations, even those less than a
+	// day, renew the self-signed cert.
+	renewedCAConfig, err := RenewSelfSignedCertificate(caConfig, duration, false)
+	if err != nil {
+		return caConfig, err
+	}
+	return renewedCAConfig, nil
+}
+
+// RenewSelfSignedCertificate updates the expiry and optionally the serial number of the
+// provided self-signed CA.
+func RenewSelfSignedCertificate(caConfig *crypto.TLSCertificateConfig, duration time.Duration, incrementSerial bool) (*crypto.TLSCertificateConfig, error) {
+	caCert := caConfig.Certs[0]
+
+	// Copy the ca cert to avoid modifying the one provided
+	template, err := x509.ParseCertificate(caCert.Raw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy ca certificate: %v", err)
+	}
+
+	// Update the expiry
+	expiry := time.Now().Add(duration)
+	template.NotAfter = expiry
+
+	if incrementSerial {
+		template.SerialNumber = template.SerialNumber.Add(template.SerialNumber, big.NewInt(1))
+	}
+
+	renewedCACert, err := util.CreateCertificate(template, template, caCert.PublicKey, caConfig.Key)
+	if err != nil {
+		return nil, fmt.Errorf("error creating ca certificate: %v", err)
+	}
+
+	return &crypto.TLSCertificateConfig{
+		Certs: []*x509.Certificate{renewedCACert},
+		Key:   caConfig.Key,
+	}, nil
+}

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -2,19 +2,39 @@ package operator
 
 import (
 	"encoding/json"
+	"time"
 )
 
 type unsupportedServiceCAConfig struct {
+	CAConfig caConfig `json:"caConfig"`
+
 	TimeBasedRotation timeBasedRotationConfig `json:"timeBasedRotation"`
 
 	ForceRotation forceRotationConfig `json:"forceRotation"`
 }
 
+type caConfig struct {
+	// validityDurationForTesting determines how long a new signing CA
+	// will be valid for from the time that it is generated. It should
+	// only be used for testing purposes and is not intended for
+	// production use. If unspecified or 0, the CA will be valid for 1
+	// year.
+	// +optional
+	ValidityDurationForTesting time.Duration `json:"validityDurationForTesting"`
+}
+
 type timeBasedRotationConfig struct {
+	// enabled determines whether automatic rotation will occur when the signing CA
+	// has less than a minimum validity duration.
+	// +optional
 	Enabled bool `json:"enabled"`
 }
 
 type forceRotationConfig struct {
+	// reason indicates why a rotation of the signing CA should be forced. If the
+	// reason is not empty and has not been recorded as an annotation on the signing
+	// secret, the rotation of the signing CA will be triggered at most once.
+	// +optional
 	Reason string `json:"reason"`
 }
 
@@ -31,8 +51,11 @@ func loadUnsupportedServiceCAConfig(raw []byte) (unsupportedServiceCAConfig, err
 // RawUnsupportedServiceCAConfig returns the raw value of the operator field
 // UnsupportedConfigOverrides for whether time-based rotation is enabled and the
 // given force rotation reason.
-func RawUnsupportedServiceCAConfig(enabled bool, reason string) ([]byte, error) {
+func RawUnsupportedServiceCAConfig(enabled bool, reason string, duration time.Duration) ([]byte, error) {
 	config := &unsupportedServiceCAConfig{
+		CAConfig: caConfig{
+			ValidityDurationForTesting: duration,
+		},
 		TimeBasedRotation: timeBasedRotationConfig{
 			Enabled: enabled,
 		},

--- a/pkg/operator/sync_common_test.go
+++ b/pkg/operator/sync_common_test.go
@@ -1,0 +1,60 @@
+package operator
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/library-go/pkg/crypto"
+)
+
+func TestInitializeSigningSecret(t *testing.T) {
+	testCases := map[string]struct {
+		duration time.Duration
+	}{
+		"Zero duration should use default expiry": {
+			duration: 0 * time.Hour,
+		},
+		"Negative duration should result in an expired cert": {
+			duration: -2 * time.Hour,
+		},
+		"Positive duration should result in a short expiry": {
+			duration: 2 * time.Hour,
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			now := time.Now()
+			secret := &corev1.Secret{}
+			initializeSigningSecret(secret, 0)
+
+			// Check that the initialized key pair is valid
+			rawCert := secret.Data[corev1.TLSCertKey]
+			rawKey := secret.Data[corev1.TLSPrivateKeyKey]
+			ca, err := crypto.GetCAFromBytes(rawCert, rawKey)
+			if err != nil {
+				t.Fatalf("Initialize signing secret failed to create a valid key pair: %v", err)
+			}
+
+			// Check that a non-zero duration affects the expiry
+
+			expiry := ca.Config.Certs[0].NotAfter
+			var minimumExpiry time.Time
+			if tc.duration == 0*time.Nanosecond {
+				minimumExpiry = now.Add(SigningCertificateLifetimeInDays)
+			} else {
+				minimumExpiry = now.Add(tc.duration)
+			}
+
+			// Without overriding time.Now, need to account for the time taken between cert
+			// generation and this check. If it's more than 30 seconds something is surely
+			// broken.
+			minimumExpiry = minimumExpiry.Add(-30 * time.Second)
+
+			if !expiry.After(minimumExpiry) {
+				t.Fatalf("Expected expiry of at least %v, got %v", minimumExpiry, expiry)
+			}
+		})
+	}
+}

--- a/test/util/cert.go
+++ b/test/util/cert.go
@@ -5,39 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"math/big"
-	"time"
-
-	"github.com/openshift/library-go/pkg/crypto"
-	"github.com/openshift/service-ca-operator/pkg/operator/util"
 )
-
-// RenewSelfSignedCertificate generates a new CA with an incremented serial number and new expiry.
-func RenewSelfSignedCertificate(caConfig *crypto.TLSCertificateConfig, expiry time.Time) (*crypto.TLSCertificateConfig, error) {
-	caCert := caConfig.Certs[0]
-
-	// Copy the ca cert to avoid modifying the one provided
-	template, err := x509.ParseCertificate(caCert.Raw)
-	if err != nil {
-		return nil, fmt.Errorf("failed to copy ca certificate: %v", err)
-	}
-
-	// Increment the serial
-	template.SerialNumber = template.SerialNumber.Add(template.SerialNumber, big.NewInt(1))
-
-	// Update the expiry
-	template.NotAfter = expiry
-
-	renewedCACert, err := util.CreateCertificate(template, template, caCert.PublicKey, caConfig.Key)
-	if err != nil {
-		return nil, fmt.Errorf("error creating ca certificate: %v", err)
-	}
-
-	return &crypto.TLSCertificateConfig{
-		Certs: []*x509.Certificate{renewedCACert},
-		Key:   caConfig.Key,
-	}, nil
-}
 
 // PemToKey creates an rsa.PrivateKey from a PEM-ecoded byte array.
 func PemToKey(keyPEM []byte) (*rsa.PrivateKey, error) {


### PR DESCRIPTION
Setting the duration of CA validity allows setting a short duration to test operator compatibility with CA rotation.

This PR is required by the proposed periodic rotation compatibility job:  https://github.com/openshift/release/pull/5930