### PR TITLE
Bug 1803282: enable signer ca expiry timer metrics

### DIFF
--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -1,0 +1,21 @@
+package metrics
+
+import (
+	"time"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var expiryTime = metrics.NewGauge(&metrics.GaugeOpts{
+	Name: "service_ca_expiry_time_seconds",
+	Help: "Reports the expiry time of service CA used in the cluster.",
+})
+
+func init() {
+	legacyregistry.MustRegister(expiryTime)
+}
+
+func SetCAExpiry(notAfter time.Time) {
+	expiryTime.Set(float64(notAfter.Unix()))
+}

--- a/pkg/operator/sync_common.go
+++ b/pkg/operator/sync_common.go
@@ -116,6 +116,7 @@ func manageSignerCA(client coreclientv1.SecretsGetter, eventRecorder events.Reco
 			return false, fmt.Errorf("failed to rotate signing CA: %v", err)
 		}
 		if len(rotationMsg) == 0 {
+			metrics.SetCAExpiry(existingCert.NotAfter)
 			return false, nil
 		}
 		// Ensure the updated existing secret is applied below

--- a/pkg/operator/sync_common.go
+++ b/pkg/operator/sync_common.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"fmt"
+	"github.com/openshift/service-ca-operator/pkg/operator/metrics"
 	"os"
 	"time"
 
@@ -120,6 +121,12 @@ func manageSignerCA(client coreclientv1.SecretsGetter, eventRecorder events.Reco
 		// Ensure the updated existing secret is applied below
 		secret = existing
 	}
+
+	certs, err := cert.ParseCertsPEM(secret.Data[corev1.TLSCertKey])
+	if err != nil {
+		return false, err
+	}
+	metrics.SetCAExpiry(certs[0].NotAfter)
 
 	_, mod, err := resourceapply.ApplySecret(client, eventRecorder, secret)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -686,7 +686,7 @@ func checkMetricsCollection(t *testing.T, promClient prometheusv1.API, namespace
 func runPromQueryForVector(t *testing.T, promClient prometheusv1.API, query string, sampleTime time.Time) (model.Vector, error) {
 	results, warnings, err := promClient.Query(context.Background(), query, sampleTime)
 	if err != nil {
-		return model.Vector{}, err
+		return nil, err
 	}
 	if len(warnings) > 0 {
 		t.Logf("prometheus query emitted warnings: %v", warnings)
@@ -694,7 +694,7 @@ func runPromQueryForVector(t *testing.T, promClient prometheusv1.API, query stri
 
 	result, ok := results.(model.Vector)
 	if !ok {
-		return model.Vector{}, fmt.Errorf("expecting vector type result, found: %v ", reflect.TypeOf(results))
+		return nil, fmt.Errorf("expecting vector type result, found: %v ", reflect.TypeOf(results))
 	}
 
 	return result, nil
@@ -735,7 +735,7 @@ func checkServiceCAMetrics(t *testing.T, client *kubernetes.Clientset, promClien
 		}
 
 		if float64(want.Unix()) != float64(rawExpiryTime.Value) {
-			t.Fatalf("service ca expiry time mismatch expected %v observed %v", float64(want.UnixNano()), float64(rawExpiryTime.Value))
+			t.Fatalf("service ca expiry time mismatch expected %v observed %v", float64(want.Unix()), float64(rawExpiryTime.Value))
 		}
 
 		return true, nil


### PR DESCRIPTION
This PR is an attempt to add expiry time and time left metrics before the signer CA expires to Prometheus collector