### PR TITLE
WIP: Add webhook CA Bundle injector

### DIFF
--- a/pkg/cmd/webhookcabundle/cmd.go
+++ b/pkg/cmd/webhookcabundle/cmd.go
@@ -1,0 +1,23 @@
+package webhookcabundle
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/service-ca-operator/pkg/controller/webhookcabundle/starter"
+	"github.com/openshift/service-ca-operator/pkg/version"
+)
+
+const (
+	componentName      = "webhook-cabundle-injector"
+	componentNamespace = "openshift-service-ca"
+)
+
+func NewController() *cobra.Command {
+	cmd := controllercmd.
+		NewControllerCommandConfig(componentName, version.Get(), starter.StartWebhookCABundleInjector).
+		NewCommand()
+	cmd.Use = "webhook-cabundle-injector"
+	cmd.Short = "Start the WebHook CA Bundle Injection controller"
+	return cmd
+}

--- a/pkg/controller/webhookcabundle/controller/webhook_cabundle_controller.go
+++ b/pkg/controller/webhookcabundle/controller/webhook_cabundle_controller.go
@@ -1,0 +1,62 @@
+package controller
+
+import (
+	"bytes"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	webhookinformer "k8s.io/client-go/informers/admissionregistration/v1beta1"
+	webhookclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
+	webhooklister "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"monis.app/go/openshift/controller"
+
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
+)
+
+type serviceServingCertUpdateController struct {
+	webhookClient webhookclient.ValidatingWebhookConfigurationsGetter
+	webhookLister webhooklister.ValidatingWebhookConfigurationLister
+
+	caBundle []byte
+}
+
+func NewWebhookCABundleInjector(webhookInformer webhookinformer.ValidatingWebhookConfigurationInformer, webhookClient webhookclient.ValidatingWebhookConfigurationsGetter, caBundle []byte) controller.Runner {
+	sc := &serviceServingCertUpdateController{
+		webhookClient: webhookClient,
+		webhookLister: webhookInformer.Lister(),
+		caBundle:      caBundle,
+	}
+
+	return controller.New("WebhookCABundleInjector", sc,
+		controller.WithInformer(webhookInformer, controller.FilterFuncs{
+			AddFunc:    api.HasInjectCABundleAnnotation,
+			UpdateFunc: api.HasInjectCABundleAnnotationUpdate,
+		}),
+	)
+}
+
+func (c *serviceServingCertUpdateController) Key(namespace, name string) (v1.Object, error) {
+	return c.webhookLister.Get(name)
+}
+
+func (c *serviceServingCertUpdateController) Sync(obj v1.Object) error {
+	webhook := obj.(*admissionregistrationv1beta1.ValidatingWebhookConfiguration)
+
+	// check if we need to do anything
+	if !api.HasInjectCABundleAnnotation(webhook) {
+		return nil
+	}
+
+	webhookCopy := webhook.DeepCopy()
+	for index, webhookConfig := range webhook.Webhooks {
+		// TODO(jaosorior): Make base64
+		if bytes.Equal(webhookConfig.ClientConfig.CABundle, c.caBundle) {
+			continue
+		}
+
+		// avoid mutating our cache
+		webhookCopy.Webhooks[index].ClientConfig.CABundle = c.caBundle
+	}
+	_, err := c.webhookClient.ValidatingWebhookConfigurations().Update(webhookCopy)
+	return err
+}

--- a/pkg/controller/webhookcabundle/starter/starter.go
+++ b/pkg/controller/webhookcabundle/starter/starter.go
@@ -1,0 +1,48 @@
+package starter
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	webhookinformer "k8s.io/client-go/informers"
+	webhookclient "k8s.io/client-go/kubernetes"
+
+	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/service-ca-operator/pkg/controller/webhookcabundle/controller"
+)
+
+func StartWebhookCABundleInjector(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
+	// TODO(marun) Allow this value to be supplied via argument
+	caBundleFile := "/var/run/configmaps/signing-cabundle/ca-bundle.crt"
+
+	caBundleContent, err := ioutil.ReadFile(caBundleFile)
+	if err != nil {
+		return err
+	}
+	encodedCaBundleContent := []byte(base64.StdEncoding.EncodeToString(caBundleContent))
+
+	webhookClient, err := webhookclient.NewForConfig(controllerContext.ProtoKubeConfig)
+	if err != nil {
+		return err
+	}
+	webhookInformers := webhookinformer.NewSharedInformerFactory(webhookClient, 2*time.Minute)
+
+	servingCertUpdateController := controller.NewWebhookCABundleInjector(
+		webhookInformers.Admissionregistration().V1beta1().ValidatingWebhookConfigurations(),
+		webhookClient.AdmissionregistrationV1beta1(),
+		encodedCaBundleContent,
+	)
+
+	stopChan := ctx.Done()
+
+	webhookInformers.Start(stopChan)
+
+	go servingCertUpdateController.Run(5, stopChan)
+
+	<-stopChan
+
+	return fmt.Errorf("stopped")
+}


### PR DESCRIPTION
This controller checks for webhooks with an annotation and injects the
CA bundle to each webhook in that webhook configuration.

Note that only validatingwebhookconfigurations are handled in this
implementation. If the need is seen, mutatingwebhookconfigurations can
be added to this controller as well.

### Note

This was added because I noticed that there wasn't a trivial way to get the certs configured for webhooks without manual configuration. The intent is to make it easy for administrators to add their own webhooks without needing to worry about certs.