### PR TITLE
Extend service CA duration to 14 months

### DIFF
--- a/pkg/operator/rotate.go
+++ b/pkg/operator/rotate.go
@@ -16,7 +16,20 @@ import (
 )
 
 const (
-	SigningCertificateLifetimeInDays = 365 // 1 year
+	// The duration of the service CA needs to exceeds the maximum supported
+	// upgrade interval (currently 12 months). A duration of 14 months
+	// ensures that an upgrade will occur after automated rotation and before
+	// the expiry of the pre-rotation CA. Since an upgrade restarts all
+	// services, those services will always be using valid material.
+	//
+	// Example timeline using a 14 month service CA duration:
+	//
+	// - T+0m  - Cluster installed with new CA or existing CA is rotated (CA-1)
+	// - T+8m  - Automated rotation replaces CA-1 with CA-2 when CA-1 duration < 6m
+	// - T+12m - Cluster is upgraded and all pods are restarted
+	// - T+14m - CA-1 expires. No impact because of the restart at time of upgrade
+	//
+	SigningCertificateLifetimeInDays = 426 // 14 months
 
 	// The minimum duration that a CA should be trusted is approximately half
 	// the default signing certificate lifetime. If a signing CA is valid for


### PR DESCRIPTION
Ensuring the CA duration exceeds the maximum supported upgrade interval (12 months) reduces the risk of services ending up using outdated key material.

The need for this change was documented in more detail in the related enhancement PR: https://github.com/openshift/enhancements/pull/181