### PR TITLE
Update new bundle injection targets to only support beta annotation

### DIFF
--- a/pkg/controller/api/api.go
+++ b/pkg/controller/api/api.go
@@ -1,11 +1,5 @@
 package api
 
-import (
-	"strings"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
 // Constants for Service CA
 const (
 	// ForcedRotationReasonAnnotationName is the name of an annotation indicating
@@ -27,15 +21,6 @@ const (
 	AlphaInjectCABundleAnnotationName = "service.alpha.openshift.io/inject-cabundle"
 	InjectionDataKey                  = "service-ca.crt"
 )
-
-func HasInjectCABundleAnnotation(metadata v1.Object) bool {
-	return strings.EqualFold(metadata.GetAnnotations()[AlphaInjectCABundleAnnotationName], "true") ||
-		strings.EqualFold(metadata.GetAnnotations()[InjectCABundleAnnotationName], "true")
-}
-
-func HasInjectCABundleAnnotationUpdate(old, cur v1.Object) bool {
-	return HasInjectCABundleAnnotation(cur)
-}
 
 // Annotations on service
 const (

--- a/pkg/controller/cabundleinjector/apiservice.go
+++ b/pkg/controller/cabundleinjector/apiservice.go
@@ -10,6 +10,8 @@ import (
 	apiserviceclientv1 "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
 	apiserviceinformer "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
 	apiservicelister "k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1"
+
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
 
 type apiServiceCABundleInjector struct {
@@ -35,6 +37,10 @@ func newAPIServiceInjectorConfig(config *caBundleInjectorConfig) controllerConfi
 		informerGetter: informer,
 		startInformers: func(stopChan <-chan struct{}) {
 			informers.Start(stopChan)
+		},
+		supportedAnnotations: []string{
+			api.InjectCABundleAnnotationName,
+			api.AlphaInjectCABundleAnnotationName,
 		},
 	}
 }

--- a/pkg/controller/cabundleinjector/configmap.go
+++ b/pkg/controller/cabundleinjector/configmap.go
@@ -29,6 +29,10 @@ func newConfigMapInjectorConfig(config *caBundleInjectorConfig) controllerConfig
 		name:           "ConfigMapCABundleInjector",
 		keySyncer:      keySyncer,
 		informerGetter: informer,
+		supportedAnnotations: []string{
+			api.InjectCABundleAnnotationName,
+			api.AlphaInjectCABundleAnnotationName,
+		},
 	}
 }
 

--- a/pkg/controller/cabundleinjector/crd.go
+++ b/pkg/controller/cabundleinjector/crd.go
@@ -10,6 +10,8 @@ import (
 	apiextlister "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
+
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
 
 type crdCABundleInjector struct {
@@ -33,6 +35,9 @@ func newCRDInjectorConfig(config *caBundleInjectorConfig) controllerConfig {
 		informerGetter: informer,
 		startInformers: func(stopChan <-chan struct{}) {
 			informers.Start(stopChan)
+		},
+		supportedAnnotations: []string{
+			api.InjectCABundleAnnotationName,
 		},
 	}
 }

--- a/pkg/controller/cabundleinjector/mutatingwebhook.go
+++ b/pkg/controller/cabundleinjector/mutatingwebhook.go
@@ -8,6 +8,8 @@ import (
 	admissionregclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	admissionreglister "k8s.io/client-go/listers/admissionregistration/v1"
 	"k8s.io/klog"
+
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
 
 type mutatingWebhookCABundleInjector struct {
@@ -27,6 +29,9 @@ func newMutatingWebhookInjectorConfig(config *caBundleInjectorConfig) controller
 		name:           "MutatingWebhookCABundleInjector",
 		keySyncer:      keySyncer,
 		informerGetter: informer,
+		supportedAnnotations: []string{
+			api.InjectCABundleAnnotationName,
+		},
 	}
 }
 

--- a/pkg/controller/cabundleinjector/validatingwebhook.go
+++ b/pkg/controller/cabundleinjector/validatingwebhook.go
@@ -8,6 +8,8 @@ import (
 	admissionregclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	admissionreglister "k8s.io/client-go/listers/admissionregistration/v1"
 	"k8s.io/klog"
+
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
 
 type validatingWebhookCABundleInjector struct {
@@ -27,6 +29,9 @@ func newValidatingWebhookInjectorConfig(config *caBundleInjectorConfig) controll
 		name:           "ValidatingWebhookCABundleInjector",
 		keySyncer:      keySyncer,
 		informerGetter: informer,
+		supportedAnnotations: []string{
+			api.InjectCABundleAnnotationName,
+		},
 	}
 }
 


### PR DESCRIPTION
Only the beta ca bundle injection annotation (`service.beta.openshift.io/inject-cabundle`) should be supported for types added in 4.4. Existing types will continue to support both the alpha and beta annotations.