### PR TITLE
Fix CA bundle annotation check to be case-insensitive

### DIFF
--- a/pkg/controller/cabundleinjector/starter.go
+++ b/pkg/controller/cabundleinjector/starter.go
@@ -3,6 +3,7 @@ package cabundleinjector
 import (
 	"context"
 	"io/ioutil"
+	"strings"
 	"time"
 
 	"monis.app/go/openshift/controller"
@@ -100,7 +101,7 @@ func StartCABundleInjector(ctx context.Context, controllerContext *controllercmd
 func hasSupportedInjectionAnnotation(obj v1.Object, supportedAnnotations []string) bool {
 	annotations := obj.GetAnnotations()
 	for _, key := range supportedAnnotations {
-		if annotations[key] == "true" {
+		if strings.EqualFold(annotations[key], "true") {
 			return true
 		}
 	}


### PR DESCRIPTION
#102 changed the check for annotation for injection to be case-sensitive, which represented a regression.