### PR TITLE
Update CA duration to 26 months to ensure upgrade after rotation

### DIFF
--- a/pkg/operator/rotate.go
+++ b/pkg/operator/rotate.go
@@ -16,27 +16,28 @@ import (
 )
 
 const (
-	// The duration of the service CA needs to exceeds the maximum supported
-	// upgrade interval (currently 12 months). A duration of 14 months
-	// ensures that an upgrade will occur after automated rotation and before
-	// the expiry of the pre-rotation CA. Since an upgrade restarts all
-	// services, those services will always be using valid material.
+	// The minimum remaining duration of the service CA needs to exceeds the maximum
+	// supported upgrade interval (currently 12 months). A duration of 26 months
+	// (rotated at 13 months) ensures that an upgrade will occur after automated
+	// rotation and before the expiry of the pre-rotation CA. Since an upgrade restarts
+	// all services, those services will always be using valid material.
 	//
-	// Example timeline using a 14 month service CA duration:
+	// Example timeline using a 26 month service CA duration:
 	//
 	// - T+0m  - Cluster installed with new CA or existing CA is rotated (CA-1)
-	// - T+8m  - Automated rotation replaces CA-1 with CA-2 when CA-1 duration < 6m
 	// - T+12m - Cluster is upgraded and all pods are restarted
-	// - T+14m - CA-1 expires. No impact because of the restart at time of upgrade
+	// - T+13m - Automated rotation replaces CA-1 with CA-2 when CA-1 duration < 13m
+	// - T+24m - Cluster is upgraded and all pods are restarted
+	// - T+26m - CA-1 expires. No impact because of the restart at time of upgrade
 	//
-	SigningCertificateLifetimeInDays = 426 // 14 months
+	SigningCertificateLifetimeInDays = 790 // 26 months
 
 	// The minimum duration that a CA should be trusted is approximately half
 	// the default signing certificate lifetime. If a signing CA is valid for
 	// less than this duration, it is due for rotation. An intermediate
 	// certificate created by rotation (to ensure that the previous CA remains
 	// trusted) should be valid for at least this long.
-	minimumTrustDuration = 182 * 24 * time.Hour
+	minimumTrustDuration = 395 * 24 * time.Hour // 13 months
 )
 
 type signingCA struct {


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/193