### PR TITLE
Remove the option to disable automated CA rotation

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -8,8 +8,6 @@ import (
 type unsupportedServiceCAConfig struct {
 	CAConfig caConfig `json:"caConfig"`
 
-	TimeBasedRotation timeBasedRotationConfig `json:"timeBasedRotation"`
-
 	ForceRotation forceRotationConfig `json:"forceRotation"`
 }
 
@@ -17,17 +15,10 @@ type caConfig struct {
 	// validityDurationForTesting determines how long a new signing CA
 	// will be valid for from the time that it is generated. It should
 	// only be used for testing purposes and is not intended for
-	// production use. If unspecified or 0, the CA will be valid for 1
-	// year.
+	// production use. If unspecified or 0, the CA will be valid for 26
+	// months.
 	// +optional
 	ValidityDurationForTesting time.Duration `json:"validityDurationForTesting"`
-}
-
-type timeBasedRotationConfig struct {
-	// enabled determines whether automatic rotation will occur when the signing CA
-	// has less than a minimum validity duration.
-	// +optional
-	Enabled bool `json:"enabled"`
 }
 
 type forceRotationConfig struct {
@@ -48,16 +39,13 @@ func loadUnsupportedServiceCAConfig(raw []byte) (unsupportedServiceCAConfig, err
 	return serviceCAConfig, err
 }
 
-// RawUnsupportedServiceCAConfig returns the raw value of the operator field
-// UnsupportedConfigOverrides for whether time-based rotation is enabled and the
-// given force rotation reason.
-func RawUnsupportedServiceCAConfig(enabled bool, reason string, duration time.Duration) ([]byte, error) {
+// RawUnsupportedServiceCAConfig returns the raw value of the operator
+// field UnsupportedConfigOverrides for the given force rotation
+// reason.
+func RawUnsupportedServiceCAConfig(reason string, duration time.Duration) ([]byte, error) {
 	config := &unsupportedServiceCAConfig{
 		CAConfig: caConfig{
 			ValidityDurationForTesting: duration,
-		},
-		TimeBasedRotation: timeBasedRotationConfig{
-			Enabled: enabled,
 		},
 		ForceRotation: forceRotationConfig{
 			Reason: reason,

--- a/pkg/operator/rotate.go
+++ b/pkg/operator/rotate.go
@@ -80,11 +80,8 @@ func maybeRotateSigningSecret(secret *corev1.Secret, currentCACert *x509.Certifi
 	reason := serviceCAConfig.ForceRotation.Reason
 	forcedRotation := forcedRotationRequired(secret, reason)
 
-	timeBasedRotation := false
-	if serviceCAConfig.TimeBasedRotation.Enabled {
-		minimumExpiry := time.Now().Add(minimumTrustDuration)
-		timeBasedRotation = currentCACert.NotAfter.Before(minimumExpiry)
-	}
+	minimumExpiry := time.Now().Add(minimumTrustDuration)
+	timeBasedRotation := currentCACert.NotAfter.Before(minimumExpiry)
 
 	if !(forcedRotation || timeBasedRotation) {
 		return "", nil

--- a/pkg/operator/rotate_test.go
+++ b/pkg/operator/rotate_test.go
@@ -94,9 +94,6 @@ func TestMaybeRotateSigningSecret(t *testing.T) {
 				CAConfig: caConfig{
 					ValidityDurationForTesting: 0,
 				},
-				TimeBasedRotation: timeBasedRotationConfig{
-					Enabled: tc.rotationExpected,
-				},
 				ForceRotation: forceRotationConfig{
 					Reason: tc.reason,
 				},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -410,11 +410,6 @@ func triggerTimeBasedRotation(t *testing.T, client *kubernetes.Clientset, config
 		Key:   currentCAKey,
 	}
 
-	// Enable time-based rotation by updating the operator config.
-	timeBasedRotationEnabled := true
-	forceRotationReason := ""
-	setUnsupportedServiceCAConfig(t, config, timeBasedRotationEnabled, forceRotationReason, 0)
-
 	// Trigger rotation by renewing the current ca with an expiry that
 	// is sooner than the minimum required duration.
 	renewedCAConfig, err := operator.RenewSelfSignedCertificate(currentCAConfig, 1*time.Hour, true)
@@ -465,7 +460,7 @@ func triggerForcedRotation(t *testing.T, client *kubernetes.Clientset, config *r
 
 	// Trigger a forced rotation by updating the operator config
 	// with a reason.
-	setUnsupportedServiceCAConfig(t, config, false, "42", customDuration)
+	setUnsupportedServiceCAConfig(t, config, "42", customDuration)
 
 	signingSecret := pollForCARotation(t, client, caCertPEM, caKeyPEM)
 
@@ -480,7 +475,7 @@ func triggerForcedRotation(t *testing.T, client *kubernetes.Clientset, config *r
 	}
 }
 
-func setUnsupportedServiceCAConfig(t *testing.T, config *rest.Config, timeBasedRotationEnabled bool, forceRotationReason string, validityDuration time.Duration) {
+func setUnsupportedServiceCAConfig(t *testing.T, config *rest.Config, forceRotationReason string, validityDuration time.Duration) {
 	operatorClient, err := operatorv1client.NewForConfig(config)
 	if err != nil {
 		t.Fatalf("error creating operator client: %v", err)
@@ -489,7 +484,7 @@ func setUnsupportedServiceCAConfig(t *testing.T, config *rest.Config, timeBasedR
 	if err != nil {
 		t.Fatalf("error retrieving operator config: %v", err)
 	}
-	rawUnsupportedServiceCAConfig, err := operator.RawUnsupportedServiceCAConfig(timeBasedRotationEnabled, forceRotationReason, validityDuration)
+	rawUnsupportedServiceCAConfig, err := operator.RawUnsupportedServiceCAConfig(forceRotationReason, validityDuration)
 	if err != nil {
 		t.Fatalf("failed to create raw unsupported config overrides: %v", err)
 	}


### PR DESCRIPTION
This option was only added to disable the feature in 4.3 and is not necessary for a release that enables automated rotation.

I was tempted to just remove all unsupported configuration options since it's generally more useful to test each service for rotation compatibility in isolation, but that could be a more controversial discussion.

/cc @stlaz @sttts 