### PR TITLE
Bug 1876858: manifests: rename operator container to be more descriptive

### DIFF
--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       serviceAccountName: service-ca-operator
       containers:
-      - name: operator
+      - name: service-ca-operator
         image: quay.io/openshift/origin-service-ca-operator:v4.0
         imagePullPolicy: IfNotPresent
         command: ["service-ca-operator", "operator"]


### PR DESCRIPTION
Rename the operator container to allow for more reasonable debugging.