### PR TITLE
Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/0000_90_service-ca-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_service-ca-operator_01_prometheusrole.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_service-ca-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_service-ca-operator_02_prometheusrolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_service-ca-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_service-ca-operator_03_servicemonitor.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/00_roles.yaml
+++ b/manifests/00_roles.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -8,4 +8,5 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/02_service.yaml
+++ b/manifests/02_service.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     service.beta.openshift.io/serving-cert-secret-name: serving-cert
   labels:
     app: service-ca-operator

--- a/manifests/03_cm.yaml
+++ b/manifests/03_cm.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/03_operator.cr.yaml
+++ b/manifests/03_operator.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/manifests/04_sa.yaml
+++ b/manifests/04_sa.yaml
@@ -8,3 +8,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/07_clusteroperator.yaml
+++ b/manifests/07_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
   - name: operator


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all service-ca-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.