### PR TITLE
Fix (make verify) with Go 1.16

### DIFF
--- a/test/util/rotate.go
+++ b/test/util/rotate.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // CheckRotation validates that pre- and post-rotation servers and clients can communicate in a
@@ -110,7 +110,7 @@ func checkClientTrust(t *testing.T, testName, dnsName string, certPEM, keyPEM, b
 	// Start a server configured with the cert and key
 	go func() {
 		if err := srv.ServeTLS(ln, certFile.Name(), keyFile.Name()); err != nil && err != http.ErrServerClosed {
-			t.Fatalf("ServeTLS failed: %v", err)
+			t.Errorf("ServeTLS failed: %v", err)
 		}
 	}()
 	defer func() {
@@ -126,7 +126,7 @@ func checkClientTrust(t *testing.T, testName, dnsName string, certPEM, keyPEM, b
 	roots := x509.NewCertPool()
 	roots.AppendCertsFromPEM(bundlePEM)
 	dialer := &net.Dialer{
-		Timeout: 3600 * time.Second,
+		Timeout: 60 * time.Second,
 	}
 	client := http.Client{
 		Transport: &http.Transport{
@@ -143,6 +143,7 @@ func checkClientTrust(t *testing.T, testName, dnsName string, certPEM, keyPEM, b
 				ServerName: dnsName,
 			},
 		},
+		Timeout: 60 * time.Second,
 	}
 	clientAddress := fmt.Sprintf("https://%s:%s", dnsName, serverPort)
 	_, err = client.Get(clientAddress)


### PR DESCRIPTION
failing with
```
go vet -mod=vendor ./...
# github.com/openshift/service-ca-operator/test/util
test/util/rotate.go:113:4: call to (*T).Fatalf from a non-test goroutine
```

Aborting the test from inside a goroutine is invalid; instead, just mark the test as failed, and let the client on the main goroutine time out. By default, that waits too long and the test fails with a generic "timed out" panic, and no record of the cause, so impose a 1-minute connection/client timeout to ensure the test fails in time; 1 minute should be plenty.

We could do more work to fail immediately (e.g. by moving the client into a separate goroutine and having the main test goroutine wait for either of the client and server), but this seems good enough for an error we don't expect to happen.
