### PR TITLE
Various e2e test fixes and cleanups

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -58,7 +58,7 @@ const (
 	// Rotation of all certs and bundles is expected to take a considerable amount of time
 	// due to the operator having to restart each controller and then each controller having
 	// to acquire the leader election lease and update all targeted resources.
-	rotationTimeout = 3 * time.Minute
+	rotationTimeout = 5 * time.Minute
 	// Polling for resources related to rotation may be delayed by the number of resources
 	// that are updated in the cluster in response to rotation.
 	rotationPollTimeout = 2 * time.Minute

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -100,7 +100,6 @@ func createTestNamespace(client *kubernetes.Clientset, namespaceName string) (*v
 	return ns, err
 }
 
-// on success returns serviceName, secretName, nil
 func createServingCertAnnotatedService(client *kubernetes.Clientset, secretName, serviceName, namespace string) error {
 	_, err := client.CoreV1().Services(namespace).Create(context.TODO(), &v1.Service{
 		TypeMeta: metav1.TypeMeta{},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -170,8 +170,8 @@ func editServingSecretData(client *kubernetes.Clientset, secretName, namespace, 
 	if err != nil {
 		return err
 	}
-	time.Sleep(10 * time.Second)
-	return nil
+
+	return pollForSecretChange(client, scopy, keyName)
 }
 
 func editConfigMapCABundleInjectionData(client *kubernetes.Clientset, configMapName, namespace string) error {
@@ -188,8 +188,8 @@ func editConfigMapCABundleInjectionData(client *kubernetes.Clientset, configMapN
 	if err != nil {
 		return err
 	}
-	time.Sleep(10 * time.Second)
-	return nil
+
+	return pollForConfigMapChange(client, cmcopy, "foo")
 }
 
 func checkServiceServingCertSecretData(client *kubernetes.Clientset, secretName, namespace string) ([]byte, bool, error) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -159,18 +159,13 @@ func pollForCABundleInjectionConfigMap(client *kubernetes.Clientset, configMapNa
 	})
 }
 
-func editServiceServingSecretData(client *kubernetes.Clientset, secretName, namespace, edit string) error {
+func editServingSecretData(client *kubernetes.Clientset, secretName, namespace, keyName string) error {
 	sss, err := client.CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 	scopy := sss.DeepCopy()
-	switch edit {
-	case "badCert":
-		scopy.Data[v1.TLSCertKey] = []byte("blah")
-	case "extraData":
-		scopy.Data["foo"] = []byte("blah")
-	}
+	scopy.Data[keyName] = []byte("blah")
 	_, err = client.CoreV1().Secrets(namespace).Update(context.TODO(), scopy, metav1.UpdateOptions{})
 	if err != nil {
 		return err
@@ -1031,7 +1026,7 @@ func TestE2E(t *testing.T) {
 			t.Fatalf("error when checking serving cert secret: %v", err)
 		}
 
-		err = editServiceServingSecretData(adminClient, testSecretName, ns.Name, "badCert")
+		err = editServingSecretData(adminClient, testSecretName, ns.Name, v1.TLSCertKey)
 		if err != nil {
 			t.Fatalf("error editing serving cert secret: %v", err)
 		}
@@ -1069,7 +1064,7 @@ func TestE2E(t *testing.T) {
 			t.Fatalf("error when checking serving cert secret: %v", err)
 		}
 
-		err = editServiceServingSecretData(adminClient, testSecretName, ns.Name, "extraData")
+		err = editServingSecretData(adminClient, testSecretName, ns.Name, "foo")
 		if err != nil {
 			t.Fatalf("error editing serving cert secret: %v", err)
 		}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -922,6 +922,10 @@ func checkServiceCAMetrics(t *testing.T, client *kubernetes.Clientset, promClien
 			t.Logf("failed to get sample value: %v", err)
 			return false, nil
 		}
+		if rawExpiryTime.Value == 0 { // The operator is starting
+			t.Logf("got zero value")
+			return false, nil
+		}
 
 		if float64(want.Unix()) != float64(rawExpiryTime.Value) {
 			t.Fatalf("service ca expiry time mismatch expected %v observed %v", float64(want.Unix()), float64(rawExpiryTime.Value))

--- a/test/util/rotate.go
+++ b/test/util/rotate.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -148,7 +149,11 @@ func checkClientTrust(t *testing.T, testName, dnsName string, certPEM, keyPEM, b
 	clientAddress := fmt.Sprintf("https://%s:%s", dnsName, serverPort)
 	_, err = client.Get(clientAddress)
 	if err != nil {
-		t.Fatalf("Failed to receive output: %v", err)
+		t.Fatalf("Failed to receive output: %v\ncertPEM: %s\nkeyPEM: %s\nbundlePEM: %s", err,
+			base64.StdEncoding.EncodeToString(certPEM),
+			base64.StdEncoding.EncodeToString(keyPEM),
+			base64.StdEncoding.EncodeToString(bundlePEM),
+		)
 	}
 	// No error indicates that validation was successful
 }


### PR DESCRIPTION
This is a set of fixes to e2e tests
- fixing some bugs (or short timeouts) that show up as flakes (e.g. in https://prow.ci.openshift.org/pr-history/?org=openshift&repo=service-ca-operator&pr=143 )
- improving the code to make test development easier
- a few minor cleanups.

See individual commit messages for details.

Note primarily the commit “Don't abort metrics/service-ca-metrics before the sync finishes”, where I could see an argument that this should be changed in the code instead of the tests.
