### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/v4.0.0/controller/deployment.yaml
+++ b/bindata/v4.0.0/controller/deployment.yaml
@@ -16,6 +16,8 @@ spec:
   template:
     metadata:
       name: service-ca
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: service-ca
         service-ca: "true"

--- a/bindata/v4.0.0/controller/ns.yaml
+++ b/bindata/v4.0.0/controller/ns.yaml
@@ -4,5 +4,6 @@ metadata:
   name: openshift-service-ca
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level-: "" # remove the label on upgrades

--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -9,3 +9,4 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"

--- a/manifests/05_deploy-ibm-cloud-managed.yaml
+++ b/manifests/05_deploy-ibm-cloud-managed.yaml
@@ -15,6 +15,8 @@ spec:
       app: service-ca-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: service-ca-operator
       name: service-ca-operator

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -16,6 +16,8 @@ spec:
   template:
     metadata:
       name: service-ca-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: service-ca-operator
     spec:

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -189,6 +189,8 @@ spec:
   template:
     metadata:
       name: service-ca
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: service-ca
         service-ca: "true"
@@ -257,8 +259,10 @@ metadata:
   name: openshift-service-ca
   annotations:
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
-    openshift.io/run-level-: "" # remove the label on upgrades`)
+    openshift.io/run-level-: "" # remove the label on upgrades
+`)
 
 func v400ControllerNsYamlBytes() ([]byte, error) {
 	return _v400ControllerNsYaml, nil


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.