### PR TITLE
OWNERS: Add Bugzilla component

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,3 +6,4 @@ approvers:
   - stlaz
   - sttts
   - deads2k
+component: service-ca


### PR DESCRIPTION
This is consumed by [ART's doozer][1], and also makes it easier for folks who know which repository is bugged to file their bugs appropriately.

[1]: https://github.com/openshift/doozer/blob/aa5c59b15496fbb69ca140b2cf5506dca4daee20/doozerlib/metadata.py#L288-L343