### PR TITLE
Bug 1948012: Report the operator status as always upgradeable in serviceCA/cluster

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -88,6 +88,7 @@ func (c *serviceCAOperator) Sync(ctx context.Context, syncCtx factory.SyncContex
 			}
 			c.syncStatus(operatorConfigCopy, existingDeployments, targetDeploymentNames)
 		}
+		setUpgradeableTrue(operatorConfigCopy, "AsExpected")
 		c.updateStatus(operatorConfigCopy)
 		return err
 	}

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -65,6 +65,14 @@ func setAvailableFalse(operatorConfig *operatorv1.ServiceCA, reason, message str
 	})
 }
 
+func setUpgradeableTrue(operatorConfig *operatorv1.ServiceCA, reason string) {
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorv1.OperatorCondition{
+		Type:   operatorv1.OperatorStatusTypeUpgradeable,
+		Status: operatorv1.ConditionTrue,
+		Reason: reason,
+	})
+}
+
 func isDeploymentStatusAvailable(deploy appsv1.Deployment) bool {
 	return deploy.Status.AvailableReplicas > 0
 }


### PR DESCRIPTION
... and this will also, via library-go/pkg/operator/status, show up in ClusterOperators/service-ca , which was previously reporting the default upgradeable Statu: Unknown, Reason: NoData.

https://bugzilla.redhat.com/show_bug.cgi?id=1948012