### PR TITLE
bug 1981498: add vulnerable legacy injector to allow for upgrade clusters to use ...

### DIFF
--- a/pkg/controller/api/api.go
+++ b/pkg/controller/api/api.go
@@ -20,6 +20,10 @@ const (
 	InjectCABundleAnnotationName      = "service.beta.openshift.io/inject-cabundle"
 	AlphaInjectCABundleAnnotationName = "service.alpha.openshift.io/inject-cabundle"
 	InjectionDataKey                  = "service-ca.crt"
+
+	// VulnerableLegacyInjectCABundleAnnotationName is only honored on configmaps intended for bound token injection in
+	// migrated/upgraded clusters that have not switched to a tighter verification bundle.
+	VulnerableLegacyInjectCABundleAnnotationName = "service.alpha.openshift.io/inject-vulnerable-legacy-cabundle"
 )
 
 // Annotations on service

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -308,6 +308,27 @@ func checkConfigMapCABundleInjectionData(client *kubernetes.Clientset, configMap
 	return nil
 }
 
+func pollForConfigMapCAInjection(client *kubernetes.Clientset, configMapName, namespace string) error {
+	return wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+		cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+
+		if len(cm.Data) != 1 {
+			return false, nil
+		}
+		_, ok := cm.Data[api.InjectionDataKey]
+		if !ok {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 func pollForServiceServingSecretWithReturn(client *kubernetes.Clientset, secretName, namespace string) (*v1.Secret, error) {
 	var secret *v1.Secret
 	err := wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
@@ -1314,6 +1335,90 @@ func TestE2E(t *testing.T) {
 		err = checkConfigMapCABundleInjectionData(adminClient, testConfigMapName, ns.Name)
 		if err != nil {
 			t.Fatalf("error when checking ca bundle injection configmap: %v", err)
+		}
+	})
+
+	// test vulnerable-legacy ca bundle injection configmap
+	t.Run("vulnerable-legacy-ca-bundle-injection-configmap", func(t *testing.T) {
+		ns, cleanup, err := createTestNamespace(t, adminClient, "test-"+randSeq(5))
+		if err != nil {
+			t.Fatalf("could not create test namespace: %v", err)
+		}
+		defer cleanup()
+
+		// names other than the one we need are never published to
+		neverPublished := &v1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-configmap-" + randSeq(5),
+				Annotations: map[string]string{api.VulnerableLegacyInjectCABundleAnnotationName: "true"},
+			},
+		}
+		_, err = adminClient.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), neverPublished, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		// with this name, content should never be published.  We wait ten seconds
+		err = pollForConfigMapCAInjection(adminClient, neverPublished.Name, ns.Name)
+		if err != wait.ErrWaitTimeout {
+			t.Fatal(err)
+		}
+
+		publishedConfigMap := &v1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "openshift-service-ca.crt",
+				Annotations: map[string]string{api.VulnerableLegacyInjectCABundleAnnotationName: "true"},
+			},
+		}
+		publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), publishedConfigMap, metav1.CreateOptions{})
+		// tolerate "already exists" to handle the case where we're running the e2e on a cluster that already has this
+		// configmap present and injected.
+		if err != nil && !errors.IsAlreadyExists(err) {
+			t.Fatal(err)
+		}
+		publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), "openshift-service-ca.crt", metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// this one should be injected
+		err = pollForConfigMapCAInjection(adminClient, publishedConfigMap.Name, ns.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		originalContent := publishedConfigMap.Data[api.InjectionDataKey]
+
+		_, hasNewStyleAnnotation := publishedConfigMap.Annotations[api.InjectCABundleAnnotationName]
+		if hasNewStyleAnnotation {
+			// add old injection to be sure only new is honored
+			publishedConfigMap.Annotations[api.VulnerableLegacyInjectCABundleAnnotationName] = "true"
+			publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Update(context.TODO(), publishedConfigMap, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			// hand-off to new injector
+			publishedConfigMap.Annotations[api.InjectCABundleAnnotationName] = "true"
+			publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Update(context.TODO(), publishedConfigMap, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// the content should now change pretty quick.  We sleep because it's easier than writing a new poll and I'm pressed for time
+		time.Sleep(5 * time.Second)
+		publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), publishedConfigMap.Name, metav1.GetOptions{})
+
+		// if we changed the injection, we should see different content
+		if hasNewStyleAnnotation {
+			if publishedConfigMap.Data[api.InjectionDataKey] != originalContent {
+				t.Fatal("Content switch and it should not have.  The better ca bundle should win.")
+			}
+		} else {
+			if publishedConfigMap.Data[api.InjectionDataKey] == originalContent {
+				t.Fatal("Content did not update like it was supposed to.  The better ca bundle should win.")
+			}
 		}
 	})
 


### PR DESCRIPTION
the old service-ca.crt content in SA tokens


This is part 1 of a four part plan.

1. add the ability to inject *only* an openshift-service-ca.crt configmap with content that in 4.7 was contained in token SA service-ca.crt.  It uses the `service.alpha.openshift.io/inject-vulnerable-legacy-cabundle` annotation so that it is clearly undesireable and the behavior isn't guaranteed.  The controller here yields to the preferred controller if both annotations are set.
2. add an API field to the kcm operator resource so a user can indicate they wish to switch to a more secure service-ca.crt.
3. Add a flag to the KCM to indicate "use the vulnerable annotation" during configmap creation. The bootstrap kcm does not need this since it is only used in new clusters.
4. set the new API field into the kcm-o "create-only" operator resource.  This will let new clusters start secure.  The operator will use the field to set the KCM flag