### PR TITLE
Bug 1987029: Support external control plane topology

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -99,6 +99,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	operator := NewServiceCAOperator(
 		operatorClient,
 		kubeInformersNamespaced,
+		configInformers,
 		kubeClient.AppsV1(),
 		kubeClient.CoreV1(),
 		kubeClient.RbacV1(),

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -1,0 +1,52 @@
+package operator
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestShouldScheduleOnWorkers(t *testing.T) {
+	tests := []struct {
+		name   string
+		infra  *configv1.Infrastructure
+		expect bool
+	}{
+		{
+			name: "ha topology",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					ControlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "non-ha topology",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "external topology",
+			infra: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					ControlPlaneTopology: configv1.ExternalTopologyMode,
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := shouldScheduleOnWorkers(test.infra)
+			if result != test.expect {
+				t.Errorf("Unexpected result: %v", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If running on an external control plane topology, there are no master
nodes. Adds a check and removes the service-ca deployment's master node
selector when running on a cluster with external control plane.