### PR TITLE
 Bug 1986829: metrics: use client cert auth for metrics scraping

### DIFF
--- a/manifests/0000_90_service-ca-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_service-ca-operator_03_servicemonitor.yaml
@@ -16,6 +16,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-service-ca-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: component
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
The CMO is now capable of using client cert auth to scrape the metrics endpoints. Use that in our components to reduce API load and allow metrics collection when the API is down - given further authz conditions are met.

/assign @s-urbaniak 