### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         app: service-ca-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: service-ca-operator
       securityContext:
         runAsNonRoot: true
@@ -28,6 +32,10 @@ spec:
         runAsUser: 1001
       containers:
       - name: service-ca-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: quay.io/openshift/origin-service-ca-operator:v4.0
         imagePullPolicy: IfNotPresent
         command: ["service-ca-operator", "operator"]


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-service-ca-operator/deployments/service-ca-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"service-ca-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabi
lities (container \"service-ca-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), seccompProfile (pod or container \"service-ca-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Note: This is blocked until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1338 merges.

/cc  @stlaz 