### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/05_deploy-ibm-cloud-managed.yaml
+++ b/manifests/05_deploy-ibm-cloud-managed.yaml
@@ -40,6 +40,11 @@ spec:
           requests:
             cpu: 10m
             memory: 80Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
@@ -50,6 +55,8 @@ spec:
         runAsGroup: 1001
         runAsNonRoot: true
         runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: service-ca-operator
       tolerations:
       - effect: NoSchedule

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -26,8 +26,15 @@ spec:
         runAsNonRoot: true
         runAsGroup: 1001
         runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: service-ca-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         image: quay.io/openshift/origin-service-ca-operator:v4.0
         imagePullPolicy: IfNotPresent
         command: ["service-ca-operator", "operator"]


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-service-ca-operator/deployments/service-ca-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"service-ca-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabi
lities (container \"service-ca-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), seccompProfile (pod or container \"service-ca-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

Note: This is blocked until https://github.com/openshift/cluster-kube-apiserver-operator/pull/1338 merges.

/cc  @stlaz 