### PR TITLE
Bug 2101880: operator NS manifest: Set empty openshift.io/run-level

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
   name: openshift-service-ca-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"


### PR DESCRIPTION
We dropped the run-level label from this namespace back in 4.5
but because of how the cluster-version operator reconciles manifest
labels, dropping a label from the manifest does not remove it from the
in-cluster resource when old clusters are updated into the new
manifest.  This commit uses the approach the cluster-version
operator used to drop its run-level, by setting the value to an
empty string, which the run-level-consuming code treats identically to
an unset label.

This avoids errors about:

  ...container has runAsNonRoot and image will run as root...

when updating to 4.11 in case the operator deployment  manifest specifically
requests runAsNonRoot: true.