### PR TITLE
Fix WebhookConfiguration cabundle injection when some webhooks need to be synced

### DIFF
--- a/pkg/controller/cabundleinjector/mutatingwebhook.go
+++ b/pkg/controller/cabundleinjector/mutatingwebhook.go
@@ -57,7 +57,7 @@ func (bi *mutatingWebhookCABundleInjector) Sync(ctx context.Context, syncCtx fac
 
 	// make a copy to avoid mutating cache state
 	webhookConfigCopy := webhookConfig.DeepCopy()
-	for i := range webhooksNeedingUpdate {
+	for _, i := range webhooksNeedingUpdate {
 		webhookConfigCopy.Webhooks[i].ClientConfig.CABundle = bi.caBundle
 	}
 	_, err = bi.client.Update(ctx, webhookConfigCopy, metav1.UpdateOptions{})

--- a/pkg/controller/cabundleinjector/mutatingwebhook_test.go
+++ b/pkg/controller/cabundleinjector/mutatingwebhook_test.go
@@ -1,0 +1,191 @@
+package cabundleinjector
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	admissionregclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	admissionreglister "k8s.io/client-go/listers/admissionregistration/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
+)
+
+type webhookInjectTest interface {
+	getWebhookName() string
+	getCABundle() []byte
+	injectorSetup(*testing.T, runtime.Object)
+	sync() error
+	validateAllCABundles(*testing.T, runtime.Object)
+}
+
+type mutatingInjectTest struct {
+	injector    *mutatingWebhookCABundleInjector
+	client      admissionregclient.MutatingWebhookConfigurationInterface
+	syncContext factory.SyncContext
+}
+
+var _ webhookInjectTest = &mutatingInjectTest{}
+
+func (m *mutatingInjectTest) getCABundle() []byte {
+	return []byte("TESTCABUNDLE")
+}
+
+func (m *mutatingInjectTest) getWebhookName() string {
+	return "test-mutating-webhook-configuration"
+}
+
+func (m *mutatingInjectTest) injectorSetup(t *testing.T, o runtime.Object) {
+	clientObjects := []runtime.Object{} // objects to init the kubeclient with
+
+	mwc, ok := o.(*admissionregv1.MutatingWebhookConfiguration)
+	if !ok {
+		t.Errorf("object is not of type MutatingWebhookConfiguration")
+	}
+
+	mutatingWebhookIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if mwc != nil {
+		if err := mutatingWebhookIndexer.Add(mwc); err != nil {
+			t.Fatal(err)
+			clientObjects = append(clientObjects, mwc)
+		}
+	}
+	lister := admissionreglister.NewMutatingWebhookConfigurationLister(mutatingWebhookIndexer)
+	kubeclient := fake.NewSimpleClientset(clientObjects...)
+	m.injector = &mutatingWebhookCABundleInjector{
+		client:   kubeclient.AdmissionregistrationV1().MutatingWebhookConfigurations(),
+		lister:   lister,
+		caBundle: m.getCABundle(),
+	}
+	m.client = kubeclient.AdmissionregistrationV1().MutatingWebhookConfigurations()
+	m.syncContext = newTestSyncContext(mwc.Name)
+}
+
+func (m *mutatingInjectTest) sync() error {
+	return m.injector.Sync(context.TODO(), m.syncContext)
+}
+
+func (m *mutatingInjectTest) validateAllCABundles(t *testing.T, o runtime.Object) {
+	mwc, ok := o.(*admissionregv1.MutatingWebhookConfiguration)
+	if !ok {
+		t.Errorf("object is not of type MutatingWebhookConfiguration")
+	}
+
+	for _, webhook := range mwc.Webhooks {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, m.getCABundle()) {
+			t.Errorf("expected %s, got %s", m.getCABundle(), webhook.ClientConfig.CABundle)
+		}
+	}
+}
+
+func TestMutatingWebhookCABundleInjectorSync(t *testing.T) {
+	m := mutatingInjectTest{}
+
+	// Common webhook config
+	webhookClientConfig := admissionregv1.WebhookClientConfig{
+		// A service must be specified for validation to
+		// accept a cabundle.
+		Service: &admissionregv1.ServiceReference{
+			Namespace: "foo",
+			Name:      "foo",
+		},
+	}
+	sideEffectNone := admissionregv1.SideEffectClassNone
+
+	mwc := &admissionregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: m.getWebhookName(),
+			Annotations: map[string]string{
+				api.InjectCABundleAnnotationName: "true",
+			},
+		},
+		Webhooks: []admissionregv1.MutatingWebhook{
+			// Specify 2 webhooks to ensure more than 1 webhook will be updated
+			{
+				Name:                    "ut-1.example.com",
+				ClientConfig:            webhookClientConfig,
+				SideEffects:             &sideEffectNone,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+			{
+				Name:                    "ut-2.example.com",
+				ClientConfig:            webhookClientConfig,
+				SideEffects:             &sideEffectNone,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}
+
+	m.injectorSetup(t, mwc)
+	if _, err := m.client.Create(context.TODO(), mwc, metav1.CreateOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	if err := m.sync(); err != nil {
+		t.Error(err)
+	}
+
+	mwc, err := m.client.Get(context.TODO(), m.getWebhookName(), metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+	m.validateAllCABundles(t, mwc)
+	mwc.Webhooks = append(mwc.Webhooks, admissionregv1.MutatingWebhook{
+		Name:                    "ut-3.example.com",
+		ClientConfig:            webhookClientConfig,
+		SideEffects:             &sideEffectNone,
+		AdmissionReviewVersions: []string{"v1"},
+	})
+
+	mwc, err = m.client.Update(context.TODO(), mwc, metav1.UpdateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	m.injectorSetup(t, mwc)
+	if _, err := m.client.Create(context.TODO(), mwc, metav1.CreateOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	if err := m.sync(); err != nil {
+		t.Error(err)
+	}
+
+	mwc, err = m.client.Get(context.TODO(), m.getWebhookName(), metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+	m.validateAllCABundles(t, mwc)
+}
+
+type testSyncContext struct {
+	queueKey      string
+	eventRecorder events.Recorder
+}
+
+func (c testSyncContext) Queue() workqueue.RateLimitingInterface {
+	return nil
+}
+
+func (c testSyncContext) QueueKey() string {
+	return c.queueKey
+}
+
+func (c testSyncContext) Recorder() events.Recorder {
+	return c.eventRecorder
+}
+
+func newTestSyncContext(queueKey string) factory.SyncContext {
+	return testSyncContext{
+		queueKey:      queueKey,
+		eventRecorder: events.NewInMemoryRecorder("test"),
+	}
+}

--- a/pkg/controller/cabundleinjector/validatingwebhook.go
+++ b/pkg/controller/cabundleinjector/validatingwebhook.go
@@ -59,7 +59,7 @@ func (bi *validatingWebhookCABundleInjector) Sync(ctx context.Context, syncCtx f
 
 	// make a copy to avoid mutating cache state
 	webhookConfigCopy := webhookConfig.DeepCopy()
-	for i := range webhooksNeedingUpdate {
+	for _, i := range webhooksNeedingUpdate {
 		webhookConfigCopy.Webhooks[i].ClientConfig.CABundle = bi.caBundle
 	}
 	_, err = bi.client.Update(ctx, webhookConfigCopy, metav1.UpdateOptions{})

--- a/pkg/controller/cabundleinjector/validatingwebhook_test.go
+++ b/pkg/controller/cabundleinjector/validatingwebhook_test.go
@@ -1,0 +1,157 @@
+package cabundleinjector
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	admissionregclient "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
+	admissionreglister "k8s.io/client-go/listers/admissionregistration/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/service-ca-operator/pkg/controller/api"
+)
+
+type validatingInjectTest struct {
+	injector    *validatingWebhookCABundleInjector
+	client      admissionregclient.ValidatingWebhookConfigurationInterface
+	syncContext factory.SyncContext
+}
+
+var _ webhookInjectTest = &validatingInjectTest{}
+
+func (v *validatingInjectTest) getCABundle() []byte {
+	return []byte("TESTCABUNDLE")
+}
+
+func (v *validatingInjectTest) getWebhookName() string {
+	return "test-validating-webhook-configuration"
+}
+
+func (v *validatingInjectTest) injectorSetup(t *testing.T, o runtime.Object) {
+	clientObjects := []runtime.Object{} // objects to init the kubeclient with
+
+	vwc, ok := o.(*admissionregv1.ValidatingWebhookConfiguration)
+	if !ok {
+		t.Errorf("object is not of type ValidatingWebhookConfiguration")
+	}
+
+	validatingWebhookIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	if vwc != nil {
+		if err := validatingWebhookIndexer.Add(vwc); err != nil {
+			t.Fatal(err)
+			clientObjects = append(clientObjects, vwc)
+		}
+	}
+	lister := admissionreglister.NewValidatingWebhookConfigurationLister(validatingWebhookIndexer)
+	kubeclient := fake.NewSimpleClientset(clientObjects...)
+	v.injector = &validatingWebhookCABundleInjector{
+		client:   kubeclient.AdmissionregistrationV1().ValidatingWebhookConfigurations(),
+		lister:   lister,
+		caBundle: v.getCABundle(),
+	}
+	v.client = kubeclient.AdmissionregistrationV1().ValidatingWebhookConfigurations()
+	v.syncContext = newTestSyncContext(vwc.Name)
+}
+
+func (v *validatingInjectTest) sync() error {
+	return v.injector.Sync(context.TODO(), v.syncContext)
+}
+
+func (v *validatingInjectTest) validateAllCABundles(t *testing.T, o runtime.Object) {
+	vwc, ok := o.(*admissionregv1.ValidatingWebhookConfiguration)
+	if !ok {
+		t.Errorf("object is not of type ValidatingWebhookConfiguration")
+	}
+
+	for _, webhook := range vwc.Webhooks {
+		if !bytes.Equal(webhook.ClientConfig.CABundle, v.getCABundle()) {
+			t.Errorf("expected %s, got %s", v.getCABundle(), webhook.ClientConfig.CABundle)
+		}
+	}
+}
+
+func TestValidatingWebhookCABundleInjectorSync(t *testing.T) {
+	m := validatingInjectTest{}
+
+	// Common webhook config
+	webhookClientConfig := admissionregv1.WebhookClientConfig{
+		// A service must be specified for validation to
+		// accept a cabundle.
+		Service: &admissionregv1.ServiceReference{
+			Namespace: "foo",
+			Name:      "foo",
+		},
+	}
+	sideEffectNone := admissionregv1.SideEffectClassNone
+
+	vwc := &admissionregv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: m.getWebhookName(),
+			Annotations: map[string]string{
+				api.InjectCABundleAnnotationName: "true",
+			},
+		},
+		Webhooks: []admissionregv1.ValidatingWebhook{
+			// Specify 2 webhooks to ensure more than 1 webhook will be updated
+			{
+				Name:                    "ut-1.example.com",
+				ClientConfig:            webhookClientConfig,
+				SideEffects:             &sideEffectNone,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+			{
+				Name:                    "ut-2.example.com",
+				ClientConfig:            webhookClientConfig,
+				SideEffects:             &sideEffectNone,
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}
+
+	m.injectorSetup(t, vwc)
+	if _, err := m.client.Create(context.TODO(), vwc, metav1.CreateOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	if err := m.sync(); err != nil {
+		t.Error(err)
+	}
+
+	vwc, err := m.client.Get(context.TODO(), m.getWebhookName(), metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+	m.validateAllCABundles(t, vwc)
+	vwc.Webhooks = append(vwc.Webhooks, admissionregv1.ValidatingWebhook{
+		Name:                    "ut-3.example.com",
+		ClientConfig:            webhookClientConfig,
+		SideEffects:             &sideEffectNone,
+		AdmissionReviewVersions: []string{"v1"},
+	})
+
+	vwc, err = m.client.Update(context.TODO(), vwc, metav1.UpdateOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	m.injectorSetup(t, vwc)
+	if _, err := m.client.Create(context.TODO(), vwc, metav1.CreateOptions{}); err != nil {
+		t.Error(err)
+	}
+
+	if err := m.sync(); err != nil {
+		t.Error(err)
+	}
+
+	vwc, err = m.client.Get(context.TODO(), m.getWebhookName(), metav1.GetOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+	m.validateAllCABundles(t, vwc)
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1727,7 +1727,7 @@ func TestE2E(t *testing.T) {
 				Name:                    "e2e-3.example.com",
 				ClientConfig:            webhookClientConfig,
 				SideEffects:             &sideEffectNone,
-				AdmissionReviewVersions: []string{"v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		}
 		setInjectionAnnotation(&obj.ObjectMeta)
@@ -1811,7 +1811,7 @@ func TestE2E(t *testing.T) {
 				Name:                    "e2e-3.example.com",
 				ClientConfig:            webhookClientConfig,
 				SideEffects:             &sideEffectNone,
-				AdmissionReviewVersions: []string{"v1beta1"},
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		}
 		setInjectionAnnotation(&obj.ObjectMeta)


### PR DESCRIPTION
## What does this fix?

WebhookConfigurations do not have their cabundles injected properly if some webhooks need to be synced, while others do not. 

## What was the issue?

webhooksNeedingUpdate is a slice of indices to update, when we for range we want the value (index within the webhook array) not the index of the value (index within webhooksNeedingUpdate).

EDIT: I could not find contributing guidelines in this repository, so feel free to correct me on process needed to contribute.
