### PR TITLE
API-1525: Add openshift_service-ca namespace yaml to manifests dir

### DIFF
--- a/manifests/0000_10_openshift_service-ca_00_namespace.yaml
+++ b/manifests/0000_10_openshift_service-ca_00_namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-service-ca
+  annotations:
+    openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"


### PR DESCRIPTION
When installing SNO openshift-service-ca service-ca pod takes a few minutes to start. Creating the serivce-ca namespace early allows it to get openshift.io/sa.scc.uid-range annotation and start running earlier.