### PR TITLE
add ownership for unshared secrets and configmaps

### DIFF
--- a/bindata/v4.0.0/controller/signing-cabundle.yaml
+++ b/bindata/v4.0.0/controller/signing-cabundle.yaml
@@ -3,5 +3,7 @@ kind: ConfigMap
 metadata:
   namespace: openshift-service-ca
   name: signing-cabundle
+  annotations:
+    openshift.io/owning-component: service-ca
 data:
   ca-bundle.crt:

--- a/bindata/v4.0.0/controller/signing-secret.yaml
+++ b/bindata/v4.0.0/controller/signing-secret.yaml
@@ -3,6 +3,8 @@ kind: Secret
 metadata:
   namespace: openshift-service-ca
   name: signing-key
+  annotations:
+    openshift.io/owning-component: service-ca
 type: kubernetes.io/tls
 data:
   tls.crt:

--- a/pkg/controller/api/api.go
+++ b/pkg/controller/api/api.go
@@ -13,6 +13,9 @@ const (
 	// IntermediateDataKey is the key used to identify the post-rotation
 	// trust-bridging certificate in the signing secret.
 	IntermediateDataKey = "intermediate-ca.crt"
+
+	// OwningJiraComponent is the name of the jira component owns the operator, operand, and the resource its creating
+	OwningJiraComponent = "service-ca"
 )
 
 // Constants for CA bundle injection

--- a/pkg/controller/servingcert/controller/secret_creating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/util/cert"
 	"k8s.io/klog/v2"
 
+	apiannotations "github.com/openshift/api/annotations"
 	"github.com/openshift/library-go/pkg/controller"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -327,8 +328,9 @@ func toBaseSecret(service *corev1.Service) *corev1.Secret {
 				Name:      service.Annotations[api.ServingCertSecretAnnotation],
 				Namespace: service.Namespace,
 				Annotations: map[string]string{
-					api.ServiceUIDAnnotation:  string(service.UID),
-					api.ServiceNameAnnotation: service.Name,
+					api.ServiceUIDAnnotation:          string(service.UID),
+					api.ServiceNameAnnotation:         service.Name,
+					apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 				},
 			},
 			Type: corev1.SecretTypeTLS,
@@ -340,8 +342,9 @@ func toBaseSecret(service *corev1.Service) *corev1.Secret {
 			Name:      service.Annotations[api.AlphaServingCertSecretAnnotation],
 			Namespace: service.Namespace,
 			Annotations: map[string]string{
-				api.AlphaServiceUIDAnnotation:  string(service.UID),
-				api.AlphaServiceNameAnnotation: service.Name,
+				api.AlphaServiceUIDAnnotation:     string(service.UID),
+				api.AlphaServiceNameAnnotation:    service.Name,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 		},
 		Type: corev1.SecretTypeTLS,
@@ -407,6 +410,7 @@ func toRequiredSecret(dnsSuffix string, ca *crypto.CA, intermediateCACert *x509.
 
 	secretCopy.Annotations[api.AlphaServingCertExpiryAnnotation] = servingCert.Certs[0].NotAfter.Format(time.RFC3339)
 	secretCopy.Annotations[api.ServingCertExpiryAnnotation] = servingCert.Certs[0].NotAfter.Format(time.RFC3339)
+	secretCopy.Annotations[apiannotations.OpenShiftComponent] = api.OwningJiraComponent
 
 	controller.EnsureOwnerRef(secretCopy, ownerRef(service))
 

--- a/pkg/controller/servingcert/controller/secret_creating_controller_test.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	kubediff "k8s.io/utils/diff"
 
+	apiannotations "github.com/openshift/api/annotations"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/events"
@@ -145,8 +146,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 				api.ServingCertCreatedByAnnotation:      signerName,
 			},
 			expectedSecretAnnotations: map[string]string{
-				api.AlphaServiceUIDAnnotation:  testServiceUID,
-				api.AlphaServiceNameAnnotation: testServiceName,
+				api.AlphaServiceUIDAnnotation:     testServiceUID,
+				api.AlphaServiceNameAnnotation:    testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			updateSecret:  true,
 			updateService: true,
@@ -162,8 +164,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 				api.ServingCertCreatedByAnnotation:      signerName,
 			},
 			expectedSecretAnnotations: map[string]string{
-				api.ServiceUIDAnnotation:  testServiceUID,
-				api.ServiceNameAnnotation: testServiceName,
+				api.ServiceUIDAnnotation:          testServiceUID,
+				api.ServiceNameAnnotation:         testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			updateSecret:  true,
 			updateService: true,
@@ -180,8 +183,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 				api.ServingCertCreatedByAnnotation:      signerName,
 			},
 			expectedSecretAnnotations: map[string]string{
-				api.ServiceUIDAnnotation:  testServiceUID,
-				api.ServiceNameAnnotation: testServiceName,
+				api.ServiceUIDAnnotation:          testServiceUID,
+				api.ServiceNameAnnotation:         testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			updateSecret:  true,
 			updateService: true,
@@ -201,8 +205,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 				api.ServingCertCreatedByAnnotation:      signerName,
 			},
 			expectedSecretAnnotations: map[string]string{
-				api.AlphaServiceUIDAnnotation:  testServiceUID,
-				api.AlphaServiceNameAnnotation: testServiceName,
+				api.AlphaServiceUIDAnnotation:     testServiceUID,
+				api.AlphaServiceNameAnnotation:    testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			updateSecret:  true,
 			updateService: true,
@@ -222,8 +227,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 				api.ServingCertCreatedByAnnotation:      signerName,
 			},
 			expectedSecretAnnotations: map[string]string{
-				api.ServiceUIDAnnotation:  testServiceUID,
-				api.ServiceNameAnnotation: testServiceName,
+				api.ServiceUIDAnnotation:          testServiceUID,
+				api.ServiceNameAnnotation:         testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			updateSecret:  true,
 			updateService: true,
@@ -312,8 +318,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 			},
 			secretData: generateServerCertPemForCA(t, ca, false),
 			expectedSecretAnnotations: map[string]string{
-				api.ServiceUIDAnnotation:  testServiceUID,
-				api.ServiceNameAnnotation: testServiceName,
+				api.ServiceUIDAnnotation:          testServiceUID,
+				api.ServiceNameAnnotation:         testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			expectedServiceAnnotations: map[string]string{
 				api.ServingCertSecretAnnotation: testSecretName,
@@ -331,8 +338,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 			},
 			secretData: generateServerCertPemForCA(t, ca, true),
 			expectedSecretAnnotations: map[string]string{
-				api.ServiceUIDAnnotation:  testServiceUID,
-				api.ServiceNameAnnotation: testServiceName,
+				api.ServiceUIDAnnotation:          testServiceUID,
+				api.ServiceNameAnnotation:         testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			expectedServiceAnnotations: map[string]string{
 				api.ServingCertSecretAnnotation: testSecretName,
@@ -354,8 +362,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 				api.ServingCertCreatedByAnnotation:      signerName,
 			},
 			expectedSecretAnnotations: map[string]string{
-				api.ServiceUIDAnnotation:  testServiceUID,
-				api.ServiceNameAnnotation: testServiceName,
+				api.ServiceUIDAnnotation:          testServiceUID,
+				api.ServiceNameAnnotation:         testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			updateService: true,
 			updateSecret:  true,
@@ -377,8 +386,9 @@ func TestServiceServingCertControllerSync(t *testing.T) {
 				api.ServingCertCreatedByAnnotation:      signerName,
 			},
 			expectedSecretAnnotations: map[string]string{
-				api.ServiceUIDAnnotation:  testServiceUID,
-				api.ServiceNameAnnotation: testServiceName,
+				api.ServiceUIDAnnotation:          testServiceUID,
+				api.ServiceNameAnnotation:         testServiceName,
+				apiannotations.OpenShiftComponent: api.OwningJiraComponent,
 			},
 			updateService: true,
 			updateSecret:  true,

--- a/pkg/controller/servingcert/controller/secret_updating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller.go
@@ -16,6 +16,7 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
+	apiannotations "github.com/openshift/api/annotations"
 	ocontroller "github.com/openshift/library-go/pkg/controller"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/crypto"
@@ -207,6 +208,13 @@ func (sc *serviceServingCertUpdateController) ensureSecretData(service *v1.Servi
 		}
 		return true, nil
 	}
+
+	// set the owning-component unless someone else has claimed it.
+	if !update && len(secretCopy.Annotations[apiannotations.OpenShiftComponent]) == 0 {
+		secretCopy.Annotations[apiannotations.OpenShiftComponent] = api.OwningJiraComponent
+		update = true
+	}
+
 	return update, nil
 }
 

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -415,6 +415,8 @@ kind: ConfigMap
 metadata:
   namespace: openshift-service-ca
   name: signing-cabundle
+  annotations:
+    openshift.io/owning-component: service-ca
 data:
   ca-bundle.crt:
 `)
@@ -439,6 +441,8 @@ kind: Secret
 metadata:
   namespace: openshift-service-ca
   name: signing-key
+  annotations:
+    openshift.io/owning-component: service-ca
 type: kubernetes.io/tls
 data:
   tls.crt:

--- a/vendor/github.com/openshift/api/annotations/annotations.go
+++ b/vendor/github.com/openshift/api/annotations/annotations.go
@@ -1,0 +1,34 @@
+package annotations
+
+// annotation keys
+// NEVER ADD TO THIS LIST.  Annotations need to be owned in the API groups they are associated with, so these constants end
+// up nested in an API group, not top level in the OpenShift namespace.  The items located here are examples of annotations
+// claiming a global namespace key that have never achieved global reach.  In the future, names should be based on the
+// consuming component.
+const (
+	// OpenShiftDisplayName is a common, optional annotation that stores the name displayed by a UI when referencing a resource.
+	OpenShiftDisplayName = "openshift.io/display-name"
+
+	// OpenShiftProviderDisplayNameAnnotation is the name of a provider of a resource, e.g.
+	// "Red Hat, Inc."
+	OpenShiftProviderDisplayNameAnnotation = "openshift.io/provider-display-name"
+
+	// OpenShiftDocumentationURLAnnotation is the url where documentation associated with
+	// a resource can be found.
+	OpenShiftDocumentationURLAnnotation = "openshift.io/documentation-url"
+
+	// OpenShiftSupportURLAnnotation is the url where support for a template can be found.
+	OpenShiftSupportURLAnnotation = "openshift.io/support-url"
+
+	// OpenShiftDescription is a common, optional annotation that stores the description for a resource.
+	OpenShiftDescription = "openshift.io/description"
+
+	// OpenShiftLongDescriptionAnnotation is a resource's long description
+	OpenShiftLongDescriptionAnnotation = "openshift.io/long-description"
+
+	// OpenShiftComponent is a common, optional annotation that stores the owning component for a resource.
+	// The component is for whatever bug tracker we're using.  That used to be bugzilla, now it is
+	// a jira component and subcomponent in OCPBUGS.
+	// For example, "Etcd" or "Networking / ovn-kubernetes"
+	OpenShiftComponent = "openshift.io/owning-component"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -164,6 +164,7 @@ github.com/munnerz/goautoneg
 # github.com/openshift/api v0.0.0-20231010075512-1ccc6058c62d
 ## explicit; go 1.20
 github.com/openshift/api
+github.com/openshift/api/annotations
 github.com/openshift/api/apiserver
 github.com/openshift/api/apiserver/v1
 github.com/openshift/api/apps


### PR DESCRIPTION
The openshift/api field will merge and be revendored here.

serving secrets and injected configmaps are not shared, we stomp all the keys.  Add the service-ca as the owner of these configmaps since we control the content.