### PR TITLE
remove unused loglevel

### DIFF
--- a/manifests/05_deploy-ibm-cloud-managed.yaml
+++ b/manifests/05_deploy-ibm-cloud-managed.yaml
@@ -24,7 +24,6 @@ spec:
       containers:
       - args:
         - --config=/var/run/configmaps/config/operator-config.yaml
-        - -v=2
         command:
         - service-ca-operator
         - operator

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -40,7 +40,6 @@ spec:
         command: ["service-ca-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/operator-config.yaml"
-        - "-v=2"
         resources:
           requests:
             memory: 80Mi


### PR DESCRIPTION
As the operator loglevel is controlled by the cr operatorLogLevel, and the --v in the deployment has no effect anymore, we should remove the redundant flag

/kind cleanup