### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/bindata/v4.0.0/controller/deployment.yaml
+++ b/bindata/v4.0.0/controller/deployment.yaml
@@ -36,6 +36,7 @@ spec:
           requests:
             memory: 120Mi
             cpu: 10m
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/signing-key
           name: signing-key

--- a/manifests/05_deploy-ibm-cloud-managed.yaml
+++ b/manifests/05_deploy-ibm-cloud-managed.yaml
@@ -45,6 +45,7 @@ spec:
           capabilities:
             drop:
             - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -50,6 +50,7 @@ spec:
           value: quay.io/openshift/origin-service-ca-operator:v4.0
         - name: OPERATOR_IMAGE_VERSION
           value: "0.0.1-snapshot"
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -217,6 +217,7 @@ spec:
           requests:
             memory: 120Mi
             cpu: 10m
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/secrets/signing-key
           name: signing-key


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.