### PR TITLE
OCPBUGS-57703: Updating ose-service-ca-operator-container image to be consistent with ART for 4.20

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.23-openshift-4.19
+  tag: rhel-9-release-golang-1.24-openshift-4.20

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/openshift/service-ca-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/service-ca-operator
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/service-ca-operator
 
-FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/service-ca-operator/service-ca-operator /usr/bin/
 COPY manifests /manifests
 # Using the vendored CRD ensures compatibility with 'oc explain'

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/service-ca-operator
 
-go 1.23.0
-
-toolchain go1.23.3
+go 1.24.0
 
 require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible


### PR DESCRIPTION
Updating ose-service-ca-operator-container image to be consistent with ART for 4.20