### PR TITLE
NO-JIRA: Update Owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,9 @@
 reviewers:
-  - stlaz
+  - p0lyn0mial
+  - vrutkovs
+  - bertinatto
 approvers:
-  - stlaz
-  - sttts
-  - deads2k
+  - p0lyn0mial
+  - vrutkovs
+  - bertinatto
 component: service-ca


### PR DESCRIPTION
Some of the people on [the current list](https://github.com/openshift/service-ca-operator/blob/main/OWNERS) have left, some are no longer focused here. Refer to old pr https://github.com/openshift/service-ca-operator/pull/259, updated owners.