### PR TITLE
WIP: OCPBUGS-27785: Add conflict check to prevent annotation causing infinite update loops

### DIFF
--- a/pkg/controller/cabundleinjector/admissionwebhook_test.go
+++ b/pkg/controller/cabundleinjector/admissionwebhook_test.go
@@ -70,6 +70,15 @@ func TestWebhookCABundleInjectorSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "conflicting annotations",
+			webhooks: []admissionregv1.ValidatingWebhook{
+				{
+					ClientConfig: admissionregv1.WebhookClientConfig{},
+				},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -81,6 +90,12 @@ func TestWebhookCABundleInjectorSync(t *testing.T) {
 					},
 				},
 				Webhooks: tt.webhooks,
+			}
+			if tt.name == "conflicting annotations" {
+				testWebhook.ObjectMeta.Annotations["service.beta.openshift.io/inject-cabundle"] = "true"
+				testWebhook.ObjectMeta.Labels = map[string]string{
+					"config.openshift.io/inject-trusted-cabundle": "true",
+				}
 			}
 
 			testCtx, cancel := context.WithCancel(context.Background())

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/core.go
@@ -294,6 +294,11 @@ func ApplyConfigMapImproved(ctx context.Context, client coreclientv1.ConfigMapsG
 	serviceCAInjected := required.Annotations["service.beta.openshift.io/inject-cabundle"] == "true"
 	_, newServiceCARequired := required.Data["service-ca.crt"]
 
+	// conflict check
+	if caBundleInjected && serviceCAInjected {
+		return nil, false, fmt.Errorf("ConfigMap %s/%s has both service-ca and trusted-ca injection enabled, which is not allowed", required.Namespace, required.Name)
+	}
+
 	var modifiedKeys []string
 	for existingCopyKey, existingCopyValue := range existingCopy.Data {
 		// if we're injecting a ca-bundle or a service-ca and the required isn't forcing the value, then don't use the value of existing


### PR DESCRIPTION
Add conflict check to prevent both service-ca and trusted-ca injection on the same ConfigMap


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds validation to block ConfigMaps that request both service CA and trusted CA bundle injection simultaneously.
- Bug Fixes
  - Prevents conflicting CA injections by rejecting invalid ConfigMaps, avoiding unexpected behavior.
  - Provides a clear error message identifying the affected ConfigMap and reason for rejection, improving troubleshooting.
- Tests
  - Adds a test case covering conflicting injection annotations/labels that expects an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->