### PR TITLE
NO-JIRA:Created an OWNERS file for the tests-extension directory

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,11 @@
+reviewers:
+  - p0lyn0mial
+  - bertinatto
+  - wangke19
+  - xingxingxia
+approvers:
+  - p0lyn0mial
+  - bertinatto
+  - wangke19
+  - xingxingxia
+component: service-ca-tests


### PR DESCRIPTION
Supplement to https://github.com/openshift/service-ca-operator/pull/283.
- Sets a specific component name (service-ca-tests) to distinguish it from the main service-ca component
- Follows the standard OpenShift OWNERS file format with reviewers and approvers sections
- Allows independent work on the tests-extension directory while maintaining proper review oversight
