### PR TITLE
OCPBUGS-65713,CNTRLPLANE-1544: Revert "controller deployment: Use user namespace"

### DIFF
--- a/bindata/v4.0.0/controller/deployment.yaml
+++ b/bindata/v4.0.0/controller/deployment.yaml
@@ -18,13 +18,12 @@ spec:
       name: service-ca
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v3
+        openshift.io/required-scc: restricted-v2
       labels:
         app: service-ca
         service-ca: "true"
     spec:
       serviceAccountName: service-ca
-      hostUsers: false
       containers:
       - name: service-ca-controller
         image: ${IMAGE}
@@ -32,6 +31,8 @@ spec:
         command: ["service-ca-operator", "controller"]
         ports:
         - containerPort: 8443
+        securityContext:
+          runAsNonRoot: true
         resources:
           requests:
             memory: 120Mi

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -207,13 +207,12 @@ spec:
       name: service-ca
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v3
+        openshift.io/required-scc: restricted-v2
       labels:
         app: service-ca
         service-ca: "true"
     spec:
       serviceAccountName: service-ca
-      hostUsers: false
       containers:
       - name: service-ca-controller
         image: ${IMAGE}
@@ -221,6 +220,8 @@ spec:
         command: ["service-ca-operator", "controller"]
         ports:
         - containerPort: 8443
+        securityContext:
+          runAsNonRoot: true
         resources:
           requests:
             memory: 120Mi


### PR DESCRIPTION
This reverts commit c36699d145c090dfa1b86f178c16012342acc378.

HyperShift is broken, reverts https://github.com/openshift/service-ca-operator/pull/278