### PR TITLE
CNF-23380: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/controller/servingcert/starter/starter.go
+++ b/pkg/controller/servingcert/starter/starter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -117,7 +116,7 @@ func StartServiceServingCertSigner(ctx context.Context, controllerContext *contr
 // bridge trust between the current and previous CA, but a new cluster
 // will not have a previous CA.
 func readIntermediateCACert(filename string) (*x509.Certificate, error) {
-	certsPEMBlock, err := ioutil.ReadFile(filename)
+	certsPEMBlock, err := os.ReadFile(filename)
 	if os.IsNotExist(err) {
 		klog.V(4).Infof("%q does not exist which indicates that an intermediate certificate was not specified", filename)
 		return nil, nil

--- a/test/util/rotate.go
+++ b/test/util/rotate.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -57,7 +56,7 @@ func CheckRotation(t testing.TB, dnsName string, oldCertPEM, oldKeyPEM, oldBundl
 func checkClientTrust(t testing.TB, testName, dnsName string, certPEM, keyPEM, bundlePEM []byte) {
 	// Emulate how a service will consume the serving cert by writing
 	// the cert and key to disk.
-	certFile, err := ioutil.TempFile("", v1.TLSCertKey)
+	certFile, err := os.CreateTemp("", v1.TLSCertKey)
 	if err != nil {
 		t.Fatalf("error creating tmpfile for cert: %v", err)
 
@@ -73,7 +72,7 @@ func checkClientTrust(t testing.TB, testName, dnsName string, certPEM, keyPEM, b
 		t.Fatalf("Error writing cert to disk: %v", err)
 	}
 
-	keyFile, err := ioutil.TempFile("", v1.TLSPrivateKeyKey)
+	keyFile, err := os.CreateTemp("", v1.TLSPrivateKeyKey)
 	if err != nil {
 		t.Fatalf("error creating tmpfile for key: %v", err)
 


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal code to use current Go standard library functions, replacing deprecated APIs with their modern equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->