### PR TITLE
OCPBUGS-65713,CNTRLPLANE-1544: Revert "manifests: Use user namespace for the deployment"

### DIFF
--- a/manifests/05_deploy-ibm-cloud-managed.yaml
+++ b/manifests/05_deploy-ibm-cloud-managed.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        openshift.io/required-scc: restricted-v3
+        openshift.io/required-scc: nonroot-v2
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: service-ca-operator
@@ -53,10 +53,11 @@ spec:
           name: config
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
-      hostUsers: false
       priorityClassName: system-cluster-critical
       securityContext:
+        runAsGroup: 1001
         runAsNonRoot: true
+        runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: service-ca-operator

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -18,14 +18,15 @@ spec:
       name: service-ca-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v3
+        openshift.io/required-scc: nonroot-v2
       labels:
         app: service-ca-operator
     spec:
       serviceAccountName: service-ca-operator
-      hostUsers: false
       securityContext:
         runAsNonRoot: true
+        runAsGroup: 1001
+        runAsUser: 1001
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
This reverts commit 7f239cc935fc7ffe73d1626e16e71461957c72a1.

The original PR: https://github.com/openshift/service-ca-operator/pull/277