### PR TITLE
CNTRLPLANE-2490:test/e2e: migrate serving-cert-secret-modify-bad-tlsCert test for OTE compatibility

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -1,0 +1,9 @@
+package e2e
+
+import "time"
+
+const (
+	// rotationPollTimeout is used for operations that may take longer due to
+	// cluster state changes (rotation, regeneration, etc.)
+	rotationPollTimeout = 4 * time.Minute
+)


### PR DESCRIPTION
## Summary
This PR migrates the `serving-cert-secret-modify-bad-tlsCert` test to the OTE (OpenShift Tests Extension) framework while keeping the original test unchanged.

## Changes
- Add Ginkgo wrapper in `test/e2e/e2e.go` for OTE compatibility
- Create `testServingCertSecretModifyBadTLSCert` function with `testing.TB` interface for dual compatibility
- Add helper functions `editServingSecretDataGinkgo` and `pollForSecretChangeGinkgo` (Ginkgo versions with `testing.TB`)
- Add temporary comment to `test/e2e/e2e_test.go` explaining duplication

## Test Coverage
This test verifies that modified serving cert secrets are regenerated with valid certificates, covering both regular and headless service scenarios.

## Related
- Follows the pattern established in PR #297
- Part of the ongoing OTE migration effort (one test per PR)

## Testing
- [x] Builds successfully: `go build -mod=vendor ./test/e2e/...`
- [x] OTE binary builds: `make build`
- [x] Tests discovered by OTE: `./service-ca-operator-tests-ext list`
- [x] Gofmt passes: `make update-gofmt`

/cc @openshift/service-ca-operator-reviewers