### PR TITLE
CNTRLPLANE-2491:test/e2e: migrate serving-cert-secret-add-data test for OTE compatibility

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1059,41 +1059,13 @@ func TestE2E(t *testing.T) {
 	})
 
 	// test extra data in serving-cert-secret will be removed
+	// NOTE: This test is also available in the OTE framework (test/e2e/e2e.go).
+	// This duplication is temporary until we fully migrate to OTE and validate the new e2e jobs.
+	// Eventually, all tests will run only through the OTE framework.
 	t.Run("serving-cert-secret-add-data", func(t *testing.T) {
 		for _, headless := range []bool{false, true} {
 			t.Run(fmt.Sprintf("headless=%v", headless), func(t *testing.T) {
-				ns, cleanup, err := createTestNamespace(t, adminClient, "test-"+randSeq(5))
-				if err != nil {
-					t.Fatalf("could not create test namespace: %v", err)
-				}
-				defer cleanup()
-
-				testServiceName := "test-service-" + randSeq(5)
-				testSecretName := "test-secret-" + randSeq(5)
-				err = createServingCertAnnotatedService(adminClient, testSecretName, testServiceName, ns.Name, headless)
-				if err != nil {
-					t.Fatalf("error creating annotated service: %v", err)
-				}
-				err = pollForServiceServingSecret(adminClient, testSecretName, ns.Name)
-				if err != nil {
-					t.Fatalf("error fetching created serving cert secret: %v", err)
-				}
-				originalBytes, _, err := checkServiceServingCertSecretData(adminClient, testSecretName, ns.Name)
-				if err != nil {
-					t.Fatalf("error when checking serving cert secret: %v", err)
-				}
-
-				err = editServingSecretData(t, adminClient, testSecretName, ns.Name, "foo")
-				if err != nil {
-					t.Fatalf("error editing serving cert secret: %v", err)
-				}
-				updatedBytes, _, err := checkServiceServingCertSecretData(adminClient, testSecretName, ns.Name)
-				if err != nil {
-					t.Fatalf("error when checking serving cert secret: %v", err)
-				}
-				if !bytes.Equal(originalBytes, updatedBytes) {
-					t.Fatalf("did not expect TLSCertKey to be replaced with a new cert")
-				}
+				testServingCertSecretAddData(t, headless)
 			})
 		}
 	})


### PR DESCRIPTION
## Summary
Migrate the `serving-cert-secret-add-data` test to OTE (OpenShift Tests Extension) framework following the established pattern from PR #297 and PR #298.

This test verifies that extra data added to a serving cert secret will NOT cause the TLS certificate to be regenerated (the controller should not remove extra data).

## Changes
- ✅ **Extract and share** - Moved inline test body from `e2e_test.go` into shared function `testServingCertSecretAddData()`
- ✅ **Zero duplication** - Both standard Go tests and Ginkgo tests call the same shared function
- ✅ **Dual compatibility** - Function uses `testing.TB` interface for both frameworks
- ✅ **No new test logic** - All code moved from existing `e2e_test.go` test

## Test Plan
**Local verification:**
```bash
# Standard Go test
export KUBECONFIG=/path/to/kubeconfig
go test -v ./test/e2e -run TestE2E/serving-cert-secret-add-data

# OTE test
make build
./service-ca-operator-tests-ext list | grep serving-cert-secret-add-data
./service-ca-operator-tests-ext run-suite openshift/conformance/serial -c 1
```

**CI will verify:**
- ✅ Code formatting (`make update-gofmt`)
- ✅ Code quality (`make verify-govet`)
- ✅ Standard e2e tests pass
- ✅ OTE tests discovered and run

## Files Changed
- `test/e2e/e2e.go` - Added Ginkgo wrapper and shared function (+46 lines)
- `test/e2e/e2e_test.go` - Refactored to call shared function (-32 lines)

## Related PRs
- PR #297 - `serving-cert-annotation` migration (merged)
- PR #298 - `serving-cert-secret-modify-bad-tlsCert` migration (merged)

## Migration Guide
Following pattern documented in `/home/kewang/foothold-ai/OTE_GO_TEST_MIGRATION_GUIDE.md`

**Key principle:** MOVE, DON'T COPY - Extract inline test code into shared functions that both frameworks call.