### PR TITLE
CNTRLPLANE-2494:test/e2e: migrate serving-cert-secret-delete-data test for OTE compatibility

### DIFF
--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -6,4 +6,7 @@ const (
 	// rotationPollTimeout is used for operations that may take longer due to
 	// cluster state changes (rotation, regeneration, etc.)
 	rotationPollTimeout = 4 * time.Minute
+
+	// rotationTimeout is the maximum time to wait for certificate rotation
+	rotationTimeout = 5 * time.Minute
 )


### PR DESCRIPTION
## Summary
Migrate the `serving-cert-secret-delete-data` test to OTE (OpenShift Tests Extension) framework following the established pattern from PRs #297, #298, and #299.

This test verifies that deleting a serving cert secret causes it to be regenerated and allows successful connections in practice. It tests the real-world scenario of secret deletion and recovery using the operator's metrics service.

## Changes
- ✅ **Extract and share** - Moved inline test body from `e2e_test.go` into shared function `testServingCertSecretDeleteData()`
- ✅ **Zero duplication** - Both standard Go tests and Ginkgo tests call the same shared function
- ✅ **Dual compatibility** - Function uses `testing.TB` interface for both frameworks
- ✅ **No new test logic** - All code moved from existing `e2e_test.go` test
- ✅ **Helper functions** - Created Ginkgo-compatible versions of all necessary helper functions:
  - `pollForUpdatedServingCertGinkgo` - Polls for certificate updates
  - `pollForUpdatedSecretGinkgo` - Polls for secret changes
  - `pollForResourceGinkgo` - Generic resource polling
  - `checkClientPodRcvdUpdatedServerCertGinkgo` - Verifies client can connect
  - `waitForPodPhaseGinkgo` - Waits for pod to reach specified phase
  - `deletePodGinkgo` - Cleanup helper
- ✅ **Constants** - Moved `rotationTimeout` to `constants.go` (following pattern from `rotationPollTimeout`)

## Test Plan
**Local verification:**
```bash
# Standard Go test
export KUBECONFIG=/path/to/kubeconfig
go test -v ./test/e2e -run TestE2E/serving-cert-secret-delete-data

# OTE test
make build
./service-ca-operator-tests-ext list | grep serving-cert-secret-delete-data
./service-ca-operator-tests-ext run-suite openshift/conformance/serial -c 1
```

**CI will verify:**
- ✅ Code formatting (`make update-gofmt`)
- ✅ Code quality (`make verify-govet`)
- ✅ Standard e2e tests pass
- ✅ OTE tests discovered and run

## Files Changed
- `test/e2e/constants.go` - Added `rotationTimeout` constant (+3 lines)
- `test/e2e/e2e.go` - Added Ginkgo wrapper, shared function, and helper functions (+147 lines)
- `test/e2e/e2e_test.go` - Refactored to call shared function and removed rotationTimeout constant (-28 lines)

## Related PRs
- PR #297 - `serving-cert-annotation` migration (merged)
- PR #298 - `serving-cert-secret-modify-bad-tlsCert` migration (merged)
- PR #299 - `serving-cert-secret-add-data` migration (merged)

## Migration Guide
Following pattern documented in `/home/kewang/foothold-ai/OTE_GO_TEST_MIGRATION_GUIDE.md`

**Key principle:** MOVE, DON'T COPY - Extract inline test code into shared functions that both frameworks call.

## Implementation Notes
This test is more complex than previous migrations as it:
1. Tests against the real operator metrics service in `openshift-service-ca-operator` namespace
2. Requires client pod creation to verify certificate-based connections
3. Needed 6 new Ginkgo-compatible helper functions to support the full test flow
4. Uses `ptr.To()` instead of deprecated `pointer.BoolPtr()` for modern Go style