### PR TITLE
CNTRLPLANE-2508:test/e2e: migrate vulnerable-legacy-ca-bundle-injection-configmap test for OTE compatibility

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -166,27 +166,6 @@ func editServingSecretData(t *testing.T, client *kubernetes.Clientset, secretNam
 	return pollForSecretChange(t, client, scopy, keyName)
 }
 
-func pollForConfigMapCAInjection(client *kubernetes.Clientset, configMapName, namespace string) error {
-	return wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
-		cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
-		if err != nil && errors.IsNotFound(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-
-		if len(cm.Data) != 1 {
-			return false, nil
-		}
-		_, ok := cm.Data[api.InjectionDataKey]
-		if !ok {
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
 func pollForServiceServingSecretWithReturn(client *kubernetes.Clientset, secretName, namespace string) (*v1.Secret, error) {
 	var secret *v1.Secret
 	err := wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
@@ -1055,87 +1034,11 @@ func TestE2E(t *testing.T) {
 	})
 
 	// test vulnerable-legacy ca bundle injection configmap
+	// NOTE: This test is also available in the OTE framework (test/e2e/e2e.go).
+	// This duplication is temporary until we fully migrate to OTE and validate the new e2e jobs.
+	// Eventually, all tests will run only through the OTE framework.
 	t.Run("vulnerable-legacy-ca-bundle-injection-configmap", func(t *testing.T) {
-		ns, cleanup, err := createTestNamespace(t, adminClient, "test-"+randSeq(5))
-		if err != nil {
-			t.Fatalf("could not create test namespace: %v", err)
-		}
-		defer cleanup()
-
-		// names other than the one we need are never published to
-		neverPublished := &v1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "test-configmap-" + randSeq(5),
-				Annotations: map[string]string{api.VulnerableLegacyInjectCABundleAnnotationName: "true"},
-			},
-		}
-		_, err = adminClient.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), neverPublished, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		// with this name, content should never be published.  We wait ten seconds
-		err = pollForConfigMapCAInjection(adminClient, neverPublished.Name, ns.Name)
-		if err != wait.ErrWaitTimeout {
-			t.Fatal(err)
-		}
-
-		publishedConfigMap := &v1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        "openshift-service-ca.crt",
-				Annotations: map[string]string{api.VulnerableLegacyInjectCABundleAnnotationName: "true"},
-			},
-		}
-		publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Create(context.TODO(), publishedConfigMap, metav1.CreateOptions{})
-		// tolerate "already exists" to handle the case where we're running the e2e on a cluster that already has this
-		// configmap present and injected.
-		if err != nil && !errors.IsAlreadyExists(err) {
-			t.Fatal(err)
-		}
-		publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), "openshift-service-ca.crt", metav1.GetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// this one should be injected
-		err = pollForConfigMapCAInjection(adminClient, publishedConfigMap.Name, ns.Name)
-		if err != nil {
-			t.Fatal(err)
-		}
-		originalContent := publishedConfigMap.Data[api.InjectionDataKey]
-
-		_, hasNewStyleAnnotation := publishedConfigMap.Annotations[api.InjectCABundleAnnotationName]
-		if hasNewStyleAnnotation {
-			// add old injection to be sure only new is honored
-			publishedConfigMap.Annotations[api.VulnerableLegacyInjectCABundleAnnotationName] = "true"
-			publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Update(context.TODO(), publishedConfigMap, metav1.UpdateOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-		} else {
-			// hand-off to new injector
-			publishedConfigMap.Annotations[api.InjectCABundleAnnotationName] = "true"
-			publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Update(context.TODO(), publishedConfigMap, metav1.UpdateOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-
-		// the content should now change pretty quick.  We sleep because it's easier than writing a new poll and I'm pressed for time
-		time.Sleep(5 * time.Second)
-		publishedConfigMap, err = adminClient.CoreV1().ConfigMaps(ns.Name).Get(context.TODO(), publishedConfigMap.Name, metav1.GetOptions{})
-
-		// if we changed the injection, we should see different content
-		if hasNewStyleAnnotation {
-			if publishedConfigMap.Data[api.InjectionDataKey] != originalContent {
-				t.Fatal("Content switch and it should not have.  The better ca bundle should win.")
-			}
-		} else {
-			if publishedConfigMap.Data[api.InjectionDataKey] == originalContent {
-				t.Fatal("Content did not update like it was supposed to.  The better ca bundle should win.")
-			}
-		}
+		testVulnerableLegacyCABundleInjectionConfigMap(t)
 	})
 
 	t.Run("metrics", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR migrates the `vulnerable-legacy-ca-bundle-injection-configmap` test to work with both standard Go testing and OTE (OpenShift Tests Extension) framework.

## Changes

- **Add Ginkgo wrapper** in e2e.go for OTE test discovery (6 lines)
- **Move `pollForConfigMapCAInjection` helper function** from e2e_test.go to e2e.go (24 lines)
  - Required because *_test.go files are only compiled during test builds, not when building the OTE binary
- **Extract inline test code** into shared `testVulnerableLegacyCABundleInjectionConfigMap` function (97 lines)
- **Change test function signature** to use `testing.TB` for dual framework compatibility
- **Refactor e2e_test.go** to call shared function instead of inline code (-101 lines)
- **Add comment notes** in e2e_test.go for temporary duplication (4 lines)

**Net change**: +30 lines (131 added - 101 removed)

This follows the same pattern as PR #302 which had +15 lines overhead.

## Test Functionality

This test verifies that:
1. The legacy CA bundle injection annotation (`service.alpha.openshift.io/inject-vulnerable-legacy-cabundle`) only works for the specific configmap name `openshift-service-ca.crt`
2. Random-named configmaps with the legacy annotation do NOT get injected (timeout expected)
3. The new annotation (`service.beta.openshift.io/inject-cabundle`) takes precedence over the legacy one

## Test Results

Both test frameworks work correctly:

### Standard Go Test ✅
```bash
export KUBECONFIG=~/work/openshift/env422a/kubeconfig
go test -v ./test/e2e -run "^TestE2E$/^vulnerable-legacy-ca-bundle-injection-configmap$"
```
**Result**: PASS (18.33s)

### OTE Framework ✅
```bash
export KUBECONFIG=~/work/openshift/env422a/kubeconfig
go test -v ./test/e2e -ginkgo.focus="vulnerable-legacy"
```
**Result**: Test discovered and executed successfully

## Migration Pattern

This migration follows the established pattern from PRs #298-#302:
- ✅ Minimal code transfer (no new logic added)
- ✅ Helper functions moved to e2e.go for OTE binary compilation
- ✅ Test function uses `testing.TB` interface for dual compatibility
- ✅ Ginkgo wrapper added for OTE discovery
- ✅ Inline test code replaced with function call in e2e_test.go
- ✅ Both test frameworks verified working
- ✅ Code compiles without errors
- ✅ Tests pass on actual cluster (env422a)

## Line Count Breakdown

The +30 line overhead is required because:
1. **Ginkgo wrapper** is necessary for OTE test discovery (6 lines)
2. **Shared test function** allows both frameworks to use same logic (97 lines)
3. **Helper function** must be in e2e.go (not e2e_test.go) because `*_test.go` files are only compiled during test builds, not when building the OTE binary (24 lines)
4. **Comment notes** in e2e_test.go for temporary duplication (4 lines)

## Related PRs

This continues the OTE migration effort:
- #298: serving-cert-secret-modify
- #299: serving-cert-secret-add-data
- #300: serving-cert-secret-delete-data
- #301: ca-bundle-injection-configmap
- #302: ca-bundle-injection-configmap-update (+15 lines, similar pattern)

## Test Plan

- [x] Code compiles: `go test -c ./test/e2e/`
- [x] Standard Go test passes: `go test -v ./test/e2e -run "vulnerable-legacy-ca-bundle-injection-configmap"`
- [x] Ginkgo/OTE test discovered and runs: `go test -v ./test/e2e -ginkgo.focus="vulnerable-legacy"`
- [x] Tested on live cluster (env422a with KUBECONFIG)