### PR TITLE
CNTRLPLANE-2549: test/e2e: migrate refresh-CA test for OTE compatibility

### DIFF
--- a/cmd/service-ca-operator-tests-ext/main.go
+++ b/cmd/service-ca-operator-tests-ext/main.go
@@ -69,14 +69,23 @@ func prepareOperatorTestsRegistry() (*oteextension.Registry, error) {
 	registry := oteextension.NewRegistry()
 	extension := oteextension.NewExtension("openshift", "payload", "service-ca-operator")
 
-	// The following suite runs tests that verify the operator's behaviour.
-	// This suite is executed only on pull requests targeting this repository.
-	// Tests tagged with both [Operator] and [Serial] are included in this suite.
+	// Non-disruptive tests run with default (Stable) cluster health monitoring.
 	extension.AddSuite(oteextension.Suite{
 		Name:        "openshift/service-ca-operator/operator/serial",
 		Parallelism: 1,
 		Qualifiers: []string{
-			`name.contains("[Operator]") && name.contains("[Serial]")`,
+			`name.contains("[Operator]") && name.contains("[Serial]") && !name.contains("[Disruptive]")`,
+		},
+	})
+
+	// Disruptive tests (e.g. CA rotation) that cause expected cluster-wide TLS disruption.
+	// Monitors will relax thresholds for this suite.
+	extension.AddSuite(oteextension.Suite{
+		Name:             "openshift/service-ca-operator/operator/serial-disruptive",
+		Parallelism:      1,
+		ClusterStability: oteextension.ClusterStabilityDisruptive,
+		Qualifiers: []string{
+			`name.contains("[Operator]") && name.contains("[Serial]") && name.contains("[Disruptive]")`,
 		},
 	})
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -70,6 +70,12 @@ var _ = g.Describe("[sig-service-ca] service-ca-operator", func() {
 		})
 	})
 
+	g.Context("headless-stateful-serving-cert-secret-delete-data", func() {
+		g.It("[Operator][Serial] should regenerate deleted serving cert secrets for StatefulSet with headless service", func() {
+			testHeadlessStatefulServingCertSecretDeleteData(g.GinkgoTB())
+		})
+	})
+
 	g.Context("ca-bundle-injection-configmap", func() {
 		g.It("[Operator][Serial] should inject CA bundle into annotated configmaps", func() {
 			testCABundleInjectionConfigMap(g.GinkgoTB())
@@ -88,12 +94,6 @@ var _ = g.Describe("[sig-service-ca] service-ca-operator", func() {
 		})
 	})
 
-	g.Context("headless-stateful-serving-cert-secret-delete-data", func() {
-		g.It("[Operator][Serial] should regenerate deleted serving cert secrets for StatefulSet with headless service", func() {
-			testHeadlessStatefulServingCertSecretDeleteData(g.GinkgoTB())
-		})
-	})
-
 	g.Context("metrics", func() {
 		g.It("[Operator][Serial] should collect metrics from the operator", func() {
 			testMetricsCollection(g.GinkgoTB())
@@ -101,6 +101,12 @@ var _ = g.Describe("[sig-service-ca] service-ca-operator", func() {
 
 		g.It("[Operator][Serial] should expose service CA expiry metrics", func() {
 			testServiceCAMetrics(g.GinkgoTB())
+		})
+	})
+
+	g.Context("refresh-CA", func() {
+		g.It("[Operator][Serial][Disruptive][Timeout:20m] should regenerate serving certs and configmaps when CA is deleted and recreated", func() {
+			testRefreshCA(g.GinkgoTB())
 		})
 	})
 })
@@ -1219,4 +1225,129 @@ func getSampleForPromQueryGinkgo(t testing.TB, promClient prometheusv1.API, quer
 		return nil, fmt.Errorf("no matching metrics found for query %s", query)
 	}
 	return res[0], nil
+}
+
+// testRefreshCA verifies that when the CA secret is deleted and recreated,
+// all serving certs and configmaps get updated with the new CA.
+//
+// This test uses testing.TB interface for dual-compatibility with both
+// standard Go tests and Ginkgo tests.
+//
+// This situation is temporary until we test the new e2e jobs with OTE.
+// Eventually all tests will be run only as part of the OTE framework.
+func testRefreshCA(t testing.TB) {
+	adminClient, err := getKubeClient()
+	if err != nil {
+		t.Fatalf("error getting kube client: %v", err)
+	}
+
+	ns, cleanup, err := createTestNamespace(t, adminClient, "test-"+randSeq(5))
+	if err != nil {
+		t.Fatalf("could not create test namespace: %v", err)
+	}
+	defer cleanup()
+
+	// create secrets
+	testServiceName := "test-service-" + randSeq(5)
+	testSecretName := "test-secret-" + randSeq(5)
+	testHeadlessServiceName := "test-headless-service-" + randSeq(5)
+	testHeadlessSecretName := "test-headless-secret-" + randSeq(5)
+
+	err = createServingCertAnnotatedService(adminClient, testSecretName, testServiceName, ns.Name, false)
+	if err != nil {
+		t.Fatalf("error creating annotated service: %v", err)
+	}
+	if err = createServingCertAnnotatedService(adminClient, testHeadlessSecretName, testHeadlessServiceName, ns.Name, true); err != nil {
+		t.Fatalf("error creating annotated headless service: %v", err)
+	}
+
+	secret, err := pollForServiceServingSecretWithReturn(adminClient, testSecretName, ns.Name)
+	if err != nil {
+		t.Fatalf("error fetching created serving cert secret: %v", err)
+	}
+	secretCopy := secret.DeepCopy()
+	headlessSecret, err := pollForServiceServingSecretWithReturn(adminClient, testHeadlessSecretName, ns.Name)
+	if err != nil {
+		t.Fatalf("error fetching created serving cert secret: %v", err)
+	}
+	headlessSecretCopy := headlessSecret.DeepCopy()
+
+	// create configmap
+	testConfigMapName := "test-configmap-" + randSeq(5)
+
+	err = createAnnotatedCABundleInjectionConfigMap(adminClient, testConfigMapName, ns.Name)
+	if err != nil {
+		t.Fatalf("error creating annotated configmap: %v", err)
+	}
+
+	configmap, err := pollForCABundleInjectionConfigMapWithReturn(adminClient, testConfigMapName, ns.Name)
+	if err != nil {
+		t.Fatalf("error fetching ca bundle injection configmap: %v", err)
+	}
+	err = checkConfigMapCABundleInjectionData(adminClient, testConfigMapName, ns.Name)
+	if err != nil {
+		t.Fatalf("error when checking ca bundle injection configmap: %v", err)
+	}
+	// Take the snapshot after injection is verified so the baseline includes
+	// the injected CA bundle data.
+	configmapCopy := configmap.DeepCopy()
+
+	// delete ca secret
+	err = adminClient.CoreV1().Secrets("openshift-service-ca").Delete(context.TODO(), "signing-key", metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("error deleting signing key: %v", err)
+	}
+
+	// make sure it's recreated
+	err = pollForCARecreation(adminClient)
+	if err != nil {
+		t.Fatalf("signing key was not recreated: %v", err)
+	}
+
+	err = pollForConfigMapChange(t, adminClient, configmapCopy, api.InjectionDataKey)
+	if err != nil {
+		t.Fatalf("configmap bundle did not change: %v", err)
+	}
+
+	err = pollForSecretChangeGinkgo(t, adminClient, secretCopy, v1.TLSCertKey, v1.TLSPrivateKeyKey)
+	if err != nil {
+		t.Fatalf("secret cert did not change: %v", err)
+	}
+	if err := pollForSecretChangeGinkgo(t, adminClient, headlessSecretCopy); err != nil {
+		t.Fatalf("headless secret cert did not change: %v", err)
+	}
+
+	t.Log("CA rotation test passed")
+}
+
+// pollForCABundleInjectionConfigMapWithReturn polls for a CA bundle injection configmap and returns it.
+func pollForCABundleInjectionConfigMapWithReturn(client *kubernetes.Clientset, configMapName, namespace string) (*v1.ConfigMap, error) {
+	var configmap *v1.ConfigMap
+	err := wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
+		cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		configmap = cm
+		return true, nil
+	})
+	return configmap, err
+}
+
+// pollForCARecreation polls for the signing secret to be re-created in
+// response to CA secret deletion.
+func pollForCARecreation(client *kubernetes.Clientset) error {
+	return wait.PollImmediate(time.Second, rotationPollTimeout, func() (bool, error) {
+		_, err := client.CoreV1().Secrets("openshift-service-ca").Get(context.TODO(), "signing-key", metav1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	})
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -93,22 +93,6 @@ func editServingSecretData(t *testing.T, client *kubernetes.Clientset, secretNam
 	return pollForSecretChange(t, client, scopy, keyName)
 }
 
-func pollForCABundleInjectionConfigMapWithReturn(client *kubernetes.Clientset, configMapName, namespace string) (*v1.ConfigMap, error) {
-	var configmap *v1.ConfigMap
-	err := wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
-		cm, err := client.CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
-		if err != nil && errors.IsNotFound(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		configmap = cm
-		return true, nil
-	})
-	return configmap, err
-}
-
 func pollForSecretChange(t *testing.T, client *kubernetes.Clientset, secret *v1.Secret, keysToChange ...string) error {
 	return wait.PollImmediate(pollInterval, rotationPollTimeout, func() (bool, error) {
 		s, err := client.CoreV1().Secrets(secret.Namespace).Get(context.TODO(), secret.Name, metav1.GetOptions{})
@@ -349,24 +333,6 @@ func pollForCARotation(t *testing.T, client *kubernetes.Clientset, caCertPEM, ca
 	}
 	return obj.(*v1.Secret)
 }
-
-// pollForCARecreation polls for the signing secret to be re-created in
-// response to CA secret deletion.
-func pollForCARecreation(client *kubernetes.Clientset) error {
-	return wait.PollImmediate(time.Second, rotationPollTimeout, func() (bool, error) {
-		_, err := client.CoreV1().Secrets(serviceCAControllerNamespace).Get(context.TODO(), signingKeySecretName, metav1.GetOptions{})
-		if err != nil && errors.IsNotFound(err) {
-			return false, nil
-		}
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
-}
-
-// pollForUpdatedServingCert returns the cert and key PEM if it changes from
-// that provided before the polling timeout.
 
 // pollForUpdatedSecret returns the given secret if its data changes from
 // that provided before the polling timeout.
@@ -723,80 +689,12 @@ func TestE2E(t *testing.T) {
 		})
 	})
 
+	// test CA refresh - delete and recreate CA secret, verify serving certs and configmaps are updated
+	// NOTE: This test is also available in the OTE framework (test/e2e/e2e.go).
+	// This duplication is temporary until we fully migrate to OTE and validate the new e2e jobs.
+	// Eventually, all tests will run only through the OTE framework.
 	t.Run("refresh-CA", func(t *testing.T) {
-		ns, cleanup, err := createTestNamespace(t, adminClient, "test-"+randSeq(5))
-		if err != nil {
-			t.Fatalf("could not create test namespace: %v", err)
-		}
-		defer cleanup()
-
-		// create secrets
-		testServiceName := "test-service-" + randSeq(5)
-		testSecretName := "test-secret-" + randSeq(5)
-		testHeadlessServiceName := "test-headless-service-" + randSeq(5)
-		testHeadlessSecretName := "test-headless-secret-" + randSeq(5)
-
-		err = createServingCertAnnotatedService(adminClient, testSecretName, testServiceName, ns.Name, false)
-		if err != nil {
-			t.Fatalf("error creating annotated service: %v", err)
-		}
-		if err = createServingCertAnnotatedService(adminClient, testHeadlessSecretName, testHeadlessServiceName, ns.Name, true); err != nil {
-			t.Fatalf("error creating annotated headless service: %v", err)
-		}
-
-		secret, err := pollForServiceServingSecretWithReturn(adminClient, testSecretName, ns.Name)
-		if err != nil {
-			t.Fatalf("error fetching created serving cert secret: %v", err)
-		}
-		secretCopy := secret.DeepCopy()
-		headlessSecret, err := pollForServiceServingSecretWithReturn(adminClient, testHeadlessSecretName, ns.Name)
-		if err != nil {
-			t.Fatalf("error fetching created serving cert secret: %v", err)
-		}
-		headlessSecretCopy := headlessSecret.DeepCopy()
-
-		// create configmap
-		testConfigMapName := "test-configmap-" + randSeq(5)
-
-		err = createAnnotatedCABundleInjectionConfigMap(adminClient, testConfigMapName, ns.Name)
-		if err != nil {
-			t.Fatalf("error creating annotated configmap: %v", err)
-		}
-
-		configmap, err := pollForCABundleInjectionConfigMapWithReturn(adminClient, testConfigMapName, ns.Name)
-		if err != nil {
-			t.Fatalf("error fetching ca bundle injection configmap: %v", err)
-		}
-		configmapCopy := configmap.DeepCopy()
-		err = checkConfigMapCABundleInjectionData(adminClient, testConfigMapName, ns.Name)
-		if err != nil {
-			t.Fatalf("error when checking ca bundle injection configmap: %v", err)
-		}
-
-		// delete ca secret
-		err = adminClient.CoreV1().Secrets(serviceCAControllerNamespace).Delete(context.TODO(), signingKeySecretName, metav1.DeleteOptions{})
-		if err != nil {
-			t.Fatalf("error deleting signing key: %v", err)
-		}
-
-		// make sure it's recreated
-		err = pollForCARecreation(adminClient)
-		if err != nil {
-			t.Fatalf("signing key was not recreated: %v", err)
-		}
-
-		err = pollForConfigMapChange(t, adminClient, configmapCopy, api.InjectionDataKey)
-		if err != nil {
-			t.Fatalf("configmap bundle did not change: %v", err)
-		}
-
-		err = pollForSecretChange(t, adminClient, secretCopy, v1.TLSCertKey, v1.TLSPrivateKeyKey)
-		if err != nil {
-			t.Fatalf("secret cert did not change: %v", err)
-		}
-		if err := pollForSecretChange(t, adminClient, headlessSecretCopy); err != nil {
-			t.Fatalf("headless secret cert did not change: %v", err)
-		}
+		testRefreshCA(t)
 	})
 
 	// This test triggers rotation by updating the CA to have an


### PR DESCRIPTION
## Summary

Split the OTE suite into **stable** and **disruptive** suites, and add post-rotation cluster stabilization to fix CI failures caused by the \`refresh-CA\` test's cluster-wide TLS disruption.

### Problem
The CI job \`e2e-aws-operator-serial-ote\` fails because the \`refresh-CA\` test deletes the cluster's service CA signing key (\`signing-key\` secret in \`openshift-service-ca\`), causing cluster-wide TLS disruption. The OTE framework runs \`openshift-tests\` monitors alongside the tests that detect this disruption and report failures. The current suite does not set \`ClusterStability\`, which defaults to \`Stable\` (zero disruption expected).

Additionally, the default per-test timeout in \`openshift-tests\` is 15 minutes, but the CA rotation triggers static pod operator revision rollouts (kube-apiserver, kube-controller-manager, kube-scheduler) that can take 15+ minutes to complete, causing test interruption.

### Solution

1. **Split into two suites:**
   - **Stable suite** (\`openshift/service-ca-operator/operator/serial\`): 13 non-disruptive tests with strict cluster health monitoring (\`ClusterStability: Stable\`)
   - **Disruptive suite** (\`openshift/service-ca-operator/operator/serial-disruptive\`): 1 test (refresh-CA) with relaxed monitor thresholds (\`ClusterStability: Disruptive\`)

2. **Add \`[Timeout:20m]\`** to the refresh-CA test name, which \`openshift-tests\` [parses](https://github.com/openshift/origin/blob/master/pkg/test/ginkgo/test_suite.go#L14) to override the default 15-minute per-test timeout.

3. **Add post-rotation stabilization wait** — after CA rotation completes, poll kube-apiserver, kube-controller-manager, and kube-scheduler static-pod operators until all nodes reach \`LatestAvailableRevision\` and the cluster operators report \`Available=True, Progressing=False, Degraded=False\`. This is best-effort: if operators don't fully stabilize within the timeout, the test still passes since the CA rotation itself succeeded.

   The wait is implemented inline in \`testRefreshCA\` using \`operator/v1\` nodeStatuses (not node annotations, which are absent on OCP 4.21+). It re-reads \`LatestAvailableRevision\` each poll to chase mid-rollout re-revisions automatically, and only logs on state transitions to keep output readable.

## Changes

### 1. Tag refresh-CA test as \`[Disruptive][Timeout:20m]\` in \`test/e2e/e2e.go\`

```go
// Before:
g.It("[Operator][Serial] should regenerate serving certs ...", func() {

// After:
g.It("[Operator][Serial][Disruptive][Timeout:20m] should regenerate serving certs ...", func() {
```

### 2. Split into two suites in \`cmd/service-ca-operator-tests-ext/main.go\`

```go
// Non-disruptive tests with strict cluster health monitoring.
extension.AddSuite(oteextension.Suite{
    Name:        "openshift/service-ca-operator/operator/serial",
    Parallelism: 1,
    Qualifiers:  []string{`name.contains("[Operator]") && name.contains("[Serial]") && !name.contains("[Disruptive]")`},
})

// Disruptive tests with relaxed monitor thresholds.
extension.AddSuite(oteextension.Suite{
    Name:             "openshift/service-ca-operator/operator/serial-disruptive",
    Parallelism:      1,
    ClusterStability: oteextension.ClusterStabilityDisruptive,
    Qualifiers:       []string{`name.contains("[Operator]") && name.contains("[Serial]") && name.contains("[Disruptive]")`},
})
```

### 3. Add cluster operator stabilization wait in \`test/e2e/e2e.go\`

After CA rotation succeeds, wait up to 15 minutes for kube-apiserver, kube-controller-manager, and kube-scheduler to complete their static-pod revision rollouts, then for all three cluster operators to report stable. This reduces monitor test failures from transient disruption during rollout.

## Files Modified

| File | Change |
|------|--------|
| \`cmd/service-ca-operator-tests-ext/main.go\` | Split single suite into stable + disruptive suites |
| \`test/e2e/e2e.go\` | Add \`[Disruptive][Timeout:20m]\` tag, extract \`testRefreshCA\` with \`testing.TB\` interface, add stabilization wait helpers |
| \`test/e2e/e2e_test.go\` | Delegate to shared \`testRefreshCA\` for backward compatibility with go test runner |

## Related Work

### CI Configuration
Companion PR in openshift/release to add the new CI job for the disruptive suite:
- **PR**: https://github.com/openshift/release/pull/74807
- **Job**: \`e2e-aws-operator-serial-disruptive-ote\`

### Future Work
Future CA rotation test migrations (\`time-based-ca-rotation\`, \`forced-ca-rotation\`) should also use the \`[Disruptive]\` tag so they are automatically routed to the disruptive suite.