### PR TITLE
NO-JIRA: OWNERS: remove vrutkovs and add sanchezl

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
 reviewers:
   - p0lyn0mial
-  - vrutkovs
+  - sanchezl
   - bertinatto
 approvers:
   - p0lyn0mial
-  - vrutkovs
+  - sanchezl
   - bertinatto
 component: service-ca


### PR DESCRIPTION
## Summary
- Remove engineer who is no longer with Red Hat from OWNERS file
- Add sanchezl as reviewer/approver taking over ownership

### Removed
- vrutkovs (Vadim Rutkovsky)

### Added
- sanchezl (Luis Sanchez)