### PR TITLE
MON-4515: Migrate Prometheus targets discovering from Endpoints to EndpointSlices

### DIFF
--- a/manifests/0000_90_service-ca-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_service-ca-operator_01_prometheusrole.yaml
@@ -19,3 +19,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/0000_90_service-ca-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_service-ca-operator_03_servicemonitor.yaml
@@ -26,3 +26,4 @@ spec:
   selector:
     matchLabels:
       app: service-ca-operator
+  serviceDiscoveryRole: EndpointSlice


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**

Due to the scope of changes across multiple repositories, these modifications were generated with Claude assistance.
