### PR TITLE
OCPBUGS-82110: fix service-ca-controller CrashLoop on MicroShift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,12 @@ Legacy `service.alpha.openshift.io` equivalents of both annotations are also sup
   - **Cannot be enabled on new clusters.** Validation introduced in 4.8 prevents changing the `KubeControllerManager` cluster config's `useMoreSecureServiceCA` from `"true"` to `"false"`. The only way to reproduce the legacy annotation is to start with a 4.7 install and upgrade.
   - **Deprecated but not removed.** The annotation is fully supported for upgraded clusters that already have it, but it is a known vulnerability and customers are advised to migrate their workloads off of it. It may be removed in a future release.
 
+### Feature Gates
+
+Feature gates must **not** be detected at runtime in the controller process. MicroShift does not have the `ClusterVersion` or `FeatureGate` CRDs, so creating informers for them causes the controller to crash (see OCPBUGS-82110).
+
+Instead, the **operator** detects feature gates via the standard `FeatureGateAccess` mechanism and forwards enabled gates to the controller Deployment as `--feature-gates=Key=true` CLI args (`pkg/operator/sync_common.go`). The controller receives them as a `map[string]bool` via `pkg/cmd/controller/cmd.go` and threads the map through the call chain. This means adding a new feature gate does **not** require changing function signatures — just check the map key where needed.
+
 ### Key Namespaces
 - `openshift-service-ca-operator`: Where the operator runs
 - `openshift-service-ca`: Where the controller Deployment runs

--- a/pkg/cmd/controller/cmd.go
+++ b/pkg/cmd/controller/cmd.go
@@ -14,11 +14,16 @@ import (
 )
 
 func NewController() *cobra.Command {
+	// Feature gates are supplied via CLI args by the operator process
+	// rather than detected at runtime. This avoids a dependency on the
+	// ClusterVersion and FeatureGate CRDs, which do not exist on
+	// MicroShift. See manageDeployment in pkg/operator/sync_common.go
+	// for where these args are injected.
 	var featureGates map[string]bool
 
 	cmd := controllercmd.
 		NewControllerCommandConfig("service-ca-controller", version.Get(), func(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
-			return controller.StartServiceCAControllers(ctx, controllerContext, featureGates["ShortCertRotation"])
+			return controller.StartServiceCAControllers(ctx, controllerContext, featureGates)
 		}, clock.RealClock{}).
 		NewCommand()
 	cmd.Use = "controller"

--- a/pkg/controller/servingcert/controller/secret_creating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_creating_controller.go
@@ -9,9 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/api/features"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/pki"
 	corev1 "k8s.io/api/core/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,7 +49,7 @@ func NewServiceServingCertController(
 	serviceClient kcoreclient.ServicesGetter,
 	secretClient kcoreclient.SecretsGetter,
 	configInformers configinformers.SharedInformerFactory,
-	featureGates featuregates.FeatureGate,
+	configurablePKIEnabled bool,
 	ca *crypto.CA,
 	intermediateCACert *x509.Certificate,
 	dnsSuffix string,
@@ -65,7 +63,7 @@ func NewServiceServingCertController(
 			intermediateCACert:     intermediateCACert,
 			dnsSuffix:              dnsSuffix,
 			certificateLifetime:    certificateLifetime,
-			configurablePKIEnabled: featureGates.Enabled(features.FeatureGateConfigurablePKI),
+			configurablePKIEnabled: configurablePKIEnabled,
 		},
 
 		serviceClient: serviceClient,

--- a/pkg/controller/servingcert/controller/secret_updating_controller.go
+++ b/pkg/controller/servingcert/controller/secret_updating_controller.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/api/features"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/pki"
 	v1 "k8s.io/api/core/v1"
@@ -22,7 +21,6 @@ import (
 	ocontroller "github.com/openshift/library-go/pkg/controller"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/crypto"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/service-ca-operator/pkg/controller/api"
 )
@@ -44,7 +42,7 @@ func NewServiceServingCertUpdateController(
 	secrets informers.SecretInformer,
 	secretClient kcoreclient.SecretsGetter,
 	configInformers configinformers.SharedInformerFactory,
-	featureGates featuregates.FeatureGate,
+	configurablePKIEnabled bool,
 	ca *crypto.CA,
 	intermediateCACert *x509.Certificate,
 	dnsSuffix string,
@@ -59,7 +57,7 @@ func NewServiceServingCertUpdateController(
 			intermediateCACert:     intermediateCACert,
 			dnsSuffix:              dnsSuffix,
 			certificateLifetime:    certificateLifetime,
-			configurablePKIEnabled: featureGates.Enabled(features.FeatureGateConfigurablePKI),
+			configurablePKIEnabled: configurablePKIEnabled,
 		},
 
 		secretClient:  secretClient,

--- a/pkg/controller/servingcert/starter/starter.go
+++ b/pkg/controller/servingcert/starter/starter.go
@@ -17,12 +17,10 @@ import (
 	configexternalinformers "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/crypto"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/service-ca-operator/pkg/controller/servingcert/controller"
 )
 
-func StartServiceServingCertSigner(ctx context.Context, controllerContext *controllercmd.ControllerContext, shortCertRotationEnabled bool) error {
+func StartServiceServingCertSigner(ctx context.Context, controllerContext *controllercmd.ControllerContext, enabledFeatureGates map[string]bool) error {
 	// TODO(marun) Allow the following values to be supplied via argument
 	certFile := "/var/run/secrets/signing-key/tls.crt"
 	keyFile := "/var/run/secrets/signing-key/tls.key"
@@ -45,35 +43,27 @@ func StartServiceServingCertSigner(ctx context.Context, controllerContext *contr
 	}
 	kubeInformers := informers.NewSharedInformerFactory(kubeClient, 20*time.Minute)
 
-	configClient, err := configeversionedclient.NewForConfig(controllerContext.KubeConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create config client: %w", err)
-	}
+	// Feature gates are passed to the controller via CLI args from the
+	// operator process, rather than being detected at runtime via
+	// FeatureGate/ClusterVersion informers. This is necessary because
+	// MicroShift does not have the ClusterVersion and FeatureGate CRDs,
+	// and runtime detection would cause the controller to crash.
+	configurablePKIEnabled := enabledFeatureGates["ConfigurablePKI"]
 
-	configInformers := configexternalinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
-
-	featureGateAccessor := featuregates.NewFeatureGateAccess(
-		status.VersionForOperatorFromEnv(), "0.0.1-snapshot",
-		configInformers.Config().V1().ClusterVersions(),
-		configInformers.Config().V1().FeatureGates(),
-		controllerContext.EventRecorder,
-	)
-	configInformers.Start(ctx.Done())
-	go featureGateAccessor.Run(ctx)
-
-	var featureGates featuregates.FeatureGate
-	select {
-	case <-featureGateAccessor.InitialFeatureGatesObserved():
-		featureGates, _ = featureGateAccessor.CurrentFeatureGates()
-		klog.Infof("FeatureGates initialized: knownFeatureGates=%v", featureGates.KnownFeatures())
-	case <-time.After(1 * time.Minute):
-		klog.Errorf("timed out waiting for FeatureGate detection")
-		return fmt.Errorf("timed out waiting for FeatureGate detection")
+	// Only create config informers when ConfigurablePKI is enabled, since
+	// MicroShift may not have the required config CRDs.
+	var configInformers configexternalinformers.SharedInformerFactory
+	if configurablePKIEnabled {
+		configClient, err := configeversionedclient.NewForConfig(controllerContext.KubeConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create config client: %w", err)
+		}
+		configInformers = configexternalinformers.NewSharedInformerFactory(configClient, 10*time.Minute)
 	}
 
 	minTimeLeftForCert := time.Hour
 	certificateLifetime := 2 * 365 * 24 * time.Hour
-	if shortCertRotationEnabled {
+	if enabledFeatureGates["ShortCertRotation"] {
 		minTimeLeftForCert = time.Hour
 		certificateLifetime = time.Hour * 2
 	}
@@ -85,7 +75,7 @@ func StartServiceServingCertSigner(ctx context.Context, controllerContext *contr
 		kubeClient.CoreV1(),
 		kubeClient.CoreV1(),
 		configInformers,
-		featureGates,
+		configurablePKIEnabled,
 		ca,
 		intermediateCACert,
 		// TODO this needs to be configurable
@@ -98,7 +88,7 @@ func StartServiceServingCertSigner(ctx context.Context, controllerContext *contr
 		kubeInformers.Core().V1().Secrets(),
 		kubeClient.CoreV1(),
 		configInformers,
-		featureGates,
+		configurablePKIEnabled,
 		ca,
 		intermediateCACert,
 		// TODO this needs to be configurable
@@ -109,7 +99,9 @@ func StartServiceServingCertSigner(ctx context.Context, controllerContext *contr
 	)
 
 	kubeInformers.Start(ctx.Done())
-	configInformers.Start(ctx.Done())
+	if configInformers != nil {
+		configInformers.Start(ctx.Done())
+	}
 
 	go servingCertController.Run(ctx, 5)
 	go servingCertUpdateController.Run(ctx, 5)

--- a/pkg/controller/starter.go
+++ b/pkg/controller/starter.go
@@ -8,12 +8,12 @@ import (
 	certstart "github.com/openshift/service-ca-operator/pkg/controller/servingcert/starter"
 )
 
-func StartServiceCAControllers(ctx context.Context, controllerContext *controllercmd.ControllerContext, shortCertRotationEnabled bool) error {
+func StartServiceCAControllers(ctx context.Context, controllerContext *controllercmd.ControllerContext, enabledFeatureGates map[string]bool) error {
 	err := cabundleinjector.StartCABundleInjector(ctx, controllerContext)
 	if err != nil {
 		return err
 	}
-	err = certstart.StartServiceServingCertSigner(ctx, controllerContext, shortCertRotationEnabled)
+	err = certstart.StartServiceServingCertSigner(ctx, controllerContext, enabledFeatureGates)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openshift/api/features"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -18,7 +17,6 @@ import (
 	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
 	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
-	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -41,9 +39,8 @@ type serviceCAOperator struct {
 	minimumTrustDuration       time.Duration
 	signingCertificateLifetime time.Duration
 
-	shortCertRotationEnabled bool
-	configurablePKIEnabled   bool
-	pkiProvider              pki.PKIProfileProvider
+	enabledFeatureGates map[string]bool
+	pkiProvider         pki.PKIProfileProvider
 }
 
 func NewServiceCAOperator(
@@ -58,8 +55,7 @@ func NewServiceCAOperator(
 	eventRecorder events.Recorder,
 	minimumTrustDuration time.Duration,
 	signingCertificateLifetime time.Duration,
-	shortCertRotationEnabled bool,
-	featureGates featuregates.FeatureGate,
+	enabledFeatureGates map[string]bool,
 ) factory.Controller {
 	c := &serviceCAOperator{
 		operatorClient:       operatorClient,
@@ -74,9 +70,7 @@ func NewServiceCAOperator(
 
 		minimumTrustDuration:       minimumTrustDuration,
 		signingCertificateLifetime: signingCertificateLifetime,
-		shortCertRotationEnabled:   shortCertRotationEnabled,
-
-		configurablePKIEnabled: featureGates.Enabled(features.FeatureGateConfigurablePKI),
+		enabledFeatureGates:        enabledFeatureGates,
 	}
 
 	syncInformers := []factory.Informer{
@@ -87,7 +81,7 @@ func NewServiceCAOperator(
 		operatorClient.Informers.Operator().V1().ServiceCAs().Informer(),
 		configInformers.Config().V1().Infrastructures().Informer(),
 	}
-	if c.configurablePKIEnabled {
+	if c.enabledFeatureGates["ConfigurablePKI"] {
 		syncInformers = append(syncInformers, configInformers.Config().V1alpha1().PKIs().Informer())
 		c.pkiProvider = pki.NewListerPKIProfileProvider(configInformers.Config().V1alpha1().PKIs().Lister(), "cluster")
 	}

--- a/pkg/operator/rotate.go
+++ b/pkg/operator/rotate.go
@@ -121,7 +121,7 @@ func (c *serviceCAOperator) rotateSigningCA(currentCACert *x509.Certificate, cur
 	// legacy code path.
 	var newCAConfig *crypto.TLSCertificateConfig
 	var err error
-	if c.configurablePKIEnabled {
+	if c.enabledFeatureGates["ConfigurablePKI"] {
 		var certificateCfg *pki.CertificateConfig
 		certificateCfg, err = pki.ResolveCertificateConfig(c.pkiProvider, pki.CertificateTypeSigner, "service-ca.service-serving-signer")
 		// TODO: This NotFound fallback may be temporary while ConfigurablePKI

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -149,12 +149,15 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	// trusted) should be valid for at least this long.
 	minimumTrustDuration := 395 * 24 * time.Hour
 
-	shortCertRotationEnabled := false
+	enabledFeatureGates := map[string]bool{}
 
 	if featureGates.Enabled(features.FeatureShortCertRotation) {
 		minimumTrustDuration = time.Hour + 15*time.Minute
 		signingCertificateLifetime = time.Hour*2 + 30*time.Minute
-		shortCertRotationEnabled = true
+		enabledFeatureGates["ShortCertRotation"] = true
+	}
+	if featureGates.Enabled(features.FeatureGateConfigurablePKI) {
+		enabledFeatureGates["ConfigurablePKI"] = true
 	}
 	klog.Infof("Setting signing certificate lifetime to %v, minimum trust duration to %v", signingCertificateLifetime, minimumTrustDuration)
 
@@ -169,8 +172,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		controllerContext.EventRecorder,
 		minimumTrustDuration,
 		signingCertificateLifetime,
-		shortCertRotationEnabled,
-		featureGates,
+		enabledFeatureGates,
 	)
 
 	for _, informerStarter := range []func(<-chan struct{}){

--- a/pkg/operator/sync_common.go
+++ b/pkg/operator/sync_common.go
@@ -6,6 +6,8 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/openshift/library-go/pkg/pki"
@@ -149,7 +151,7 @@ func (c *serviceCAOperator) initializeSigningSecret(secret *corev1.Secret, durat
 	// config from the PKI profile. A nil config (Unmanaged mode) means
 	// no custom key configuration is active, so fall through to the
 	// legacy code path.
-	if c.configurablePKIEnabled {
+	if c.enabledFeatureGates["ConfigurablePKI"] {
 		var certificateCfg *pki.CertificateConfig
 		certificateCfg, err = pki.ResolveCertificateConfig(c.pkiProvider, pki.CertificateTypeSigner, "service-ca.service-serving-signer")
 		// TODO: This NotFound fallback may be temporary while ConfigurablePKI
@@ -239,8 +241,8 @@ func (c *serviceCAOperator) manageDeployment(ctx context.Context, options *opera
 		}
 	}
 
-	if c.shortCertRotationEnabled {
-		required.Spec.Template.Spec.Containers[0].Args = append(required.Spec.Template.Spec.Containers[0].Args, "--feature-gates=ShortCertRotation=true")
+	if featureGateArgs := featureGateArg(c.enabledFeatureGates); len(featureGateArgs) > 0 {
+		required.Spec.Template.Spec.Containers[0].Args = append(required.Spec.Template.Spec.Containers[0].Args, featureGateArgs)
 	}
 
 	if runOnWorkers {
@@ -258,6 +260,20 @@ func (c *serviceCAOperator) manageDeployment(ctx context.Context, options *opera
 	resourcemerge.SetDeploymentGeneration(&options.Status.Generations, deployment)
 
 	return mod, nil
+}
+
+func featureGateArg(enabledFeatureGates map[string]bool) string {
+	var gates []string
+	for name, enabled := range enabledFeatureGates {
+		if enabled {
+			gates = append(gates, fmt.Sprintf("%s=true", name))
+		}
+	}
+	if len(gates) == 0 {
+		return ""
+	}
+	sort.Strings(gates)
+	return fmt.Sprintf("--feature-gates=%s", strings.Join(gates, ","))
 }
 
 func serviceServingCertSignerName() string {

--- a/pkg/operator/sync_common_test.go
+++ b/pkg/operator/sync_common_test.go
@@ -82,13 +82,13 @@ func TestManageDeployment(t *testing.T) {
 	baseDeployment := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/deployment.yaml"))
 	baseDeploymentPopulated := deployment(baseDeployment).withImage("foobar").withLogLevel(operatorv1.Normal).valueOrDie()
 	tests := []struct {
-		name                     string
-		runOnWorkers             bool
-		loglevel                 operatorv1.LogLevel
-		image                    string
-		operatorVersion          string
-		shortCertRotationEnabled bool
-		expectedDeployment       *appsv1.Deployment
+		name                string
+		runOnWorkers        bool
+		loglevel            operatorv1.LogLevel
+		image               string
+		operatorVersion     string
+		enabledFeatureGates map[string]bool
+		expectedDeployment  *appsv1.Deployment
 	}{
 		{
 			name:               "base deployment",
@@ -112,12 +112,12 @@ func TestManageDeployment(t *testing.T) {
 			expectedDeployment: deployment(baseDeployment).withImage("barbaz").withLogLevel(operatorv1.Normal).withNodeSelector(map[string]string{}).valueOrDie(),
 		},
 		{
-			name:                     "feature gates",
-			image:                    "foobar",
-			runOnWorkers:             false,
-			loglevel:                 operatorv1.Normal,
-			shortCertRotationEnabled: true,
-			expectedDeployment:       deployment(baseDeployment).withImage("foobar").withLogLevel(operatorv1.Normal).withFeatureGates([]string{"ShortCertRotation=true"}).valueOrDie(),
+			name:                "feature gates",
+			image:               "foobar",
+			runOnWorkers:        false,
+			loglevel:            operatorv1.Normal,
+			enabledFeatureGates: map[string]bool{"ShortCertRotation": true},
+			expectedDeployment:  deployment(baseDeployment).withImage("foobar").withLogLevel(operatorv1.Normal).withFeatureGates([]string{"ShortCertRotation=true"}).valueOrDie(),
 		},
 		{
 			name:               "operator version propagated to controller",
@@ -134,9 +134,9 @@ func TestManageDeployment(t *testing.T) {
 			os.Setenv("CONTROLLER_IMAGE", test.image)
 			os.Setenv(operatorVersionEnvName, test.operatorVersion)
 			operator := &serviceCAOperator{
-				appsv1Client:             appsClient,
-				eventRecorder:            events.NewInMemoryRecorder("managedeployment_test", clock.RealClock{}),
-				shortCertRotationEnabled: test.shortCertRotationEnabled,
+				appsv1Client:        appsClient,
+				eventRecorder:       events.NewInMemoryRecorder("managedeployment_test", clock.RealClock{}),
+				enabledFeatureGates: test.enabledFeatureGates,
 			}
 			serviceCA := &operatorv1.ServiceCA{
 				Spec: operatorv1.ServiceCASpec{


### PR DESCRIPTION
## Summary

- Consolidate feature gate forwarding from the operator to the controller Deployment via a single `--feature-gates` CLI arg built from a `map[string]bool`, replacing individual bool parameters
- Remove FeatureGate/ClusterVersion runtime detection from the controller process — feature gates are now exclusively received via CLI args forwarded by the operator
- Config informers for the PKI resource are only created when `ConfigurablePKI` is explicitly enabled

## Root Cause

PR #327 added `FeatureGateAccess` initialization to the controller process (`pkg/controller/servingcert/starter/starter.go`) that creates informers for `ClusterVersion` and `FeatureGate` CRDs. On MicroShift, these CRDs do not exist, so the informers fail repeatedly and the controller crashes after a 1-minute timeout.

## Test Plan

- [x] `make build`
- [x] `make test-unit`
- [ ] Verify service-ca-controller starts successfully on MicroShift without `ClusterVersion`/`FeatureGate` CRDs
- [x] Verify ConfigurablePKI still works on full OpenShift when the feature gate is enabled