### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 reviewers:
-  - p0lyn0mial
   - sanchezl
-  - bertinatto
+  - control-plane-approvers
 approvers:
-  - p0lyn0mial
   - sanchezl
-  - bertinatto
+  - control-plane-approvers
 component: service-ca

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated review and approval lists: removed two individual entries and now reference a consolidated alias group.
  * Added a new alias mapping named "control-plane-approvers" containing a predefined list of usernames to resolve the group reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->