### PR TITLE
CNTRLPLANE-3423: feat: have CVO inject the centralized TLS configuration into the operator's config

### DIFF
--- a/manifests/03_cm.yaml
+++ b/manifests/03_cm.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    config.openshift.io/inject-tls: "true"
 data:
   operator-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/05_deploy-ibm-cloud-managed.yaml
+++ b/manifests/05_deploy-ibm-cloud-managed.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
       - args:
         - --config=/var/run/configmaps/config/operator-config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/operator-config.yaml
         - -v=2
         command:
         - service-ca-operator

--- a/manifests/05_deploy.yaml
+++ b/manifests/05_deploy.yaml
@@ -41,6 +41,7 @@ spec:
         command: ["service-ca-operator", "operator"]
         args:
         - "--config=/var/run/configmaps/config/operator-config.yaml"
+        - "--terminate-on-files=/var/run/configmaps/config/operator-config.yaml"
         - "-v=2"
         resources:
           requests:


### PR DESCRIPTION
Also, have the operator restart whenever the config changes.

wip-docs: https://github.com/openshift/enhancements/pull/2020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Enabled TLS certificate injection for the service operator using a configuration annotation.
  * The service operator now terminates and restarts when its operator configuration files are updated, helping ensure new configuration and certificate material is applied promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->