### PR TITLE
[release-4.12] NO-JIRA: Updating ose-service-ca-operator-container image to be consistent with ART for 4.12

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/service-ca-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/service-ca-operator
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/service-ca-operator
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /go/src/github.com/openshift/service-ca-operator/service-ca-operator /usr/bin/
 COPY manifests /manifests
 # Using the vendored CRD ensures compatibility with 'oc explain'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/service-ca-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/pkg/operator/v4_00_assets/bindata.go
+++ b/pkg/operator/v4_00_assets/bindata.go
@@ -527,11 +527,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error


### PR DESCRIPTION
Updates the Go language version to 1.19 to align with the ART stream configuration for the release-4.12 branch across both the CI pipeline and the Dockerfile.

As a best practice, the go.mod file has also been updated to 1.19. This was validated using `mingo`, which flagged a strict requirement for 1.19 due to our upstream dependencies.

Running mingo -check -tests -deps all -strict caught the following version mismatch prior to the update:
`Error: scanning directory: go.mod declares version 1.18 but computed minimum is 1.19 [k8s.io/api@v0.25.0 declares Go version 1.19]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to support Go 1.19 and OpenShift Container Platform 4.12
  * Updated build dependencies and toolchain versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->